### PR TITLE
Split private local settings from shared dotfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ ssh/config.local
 zshrc.local
 vim/dein/repos
 vim/dein/.cache
+vim/dein/cache_vim
+vim/dein/state_vim.vim
 vim/black

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .*.swp
+ssh/config.local
+zshrc.local
 vim/dein/repos
 vim/dein/.cache
 vim/black

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@
 
 The dotfiles repository contains configuration files for the following tools:
 
+- SSH
 - tmux
 - vim
 - zsh
+- Ghostty
 - VS Code
 
 ## Install
@@ -30,6 +32,7 @@ zsh init.zsh
 ```
 
 **Note**: The installation script will automatically install Deno and configure symbolic links.
+If you split private settings into a separate repository, place it at `~/work/dotfiles-private` or set `DOTFILES_PRIVATE_DIR` before running `init.zsh`.
 
 ## Features
 ### Vim
@@ -47,8 +50,20 @@ The zsh configuration is based on [prezto](https://github.com/sorin-ionescu/prez
 
 The Python environment is managed by [pyenv](https://github.com/pyenv/pyenv), with its configuration in `zshrc`.
 
+Keep `zshrc` portable and put machine-specific values in `~/.zshrc.local` (recommended) or `zshrc.local` next to the repository copy of `zshrc`. Use it for local SDK paths and API keys; `zshrc.local.example` shows the expected shape.
+
+For remote access, define host aliases in `~/.ssh/config.local` so `cmux ssh <alias>` works without a shell wrapper. The tracked `ssh/config` contains shared defaults and includes the local file; `ssh/config.local.example` shows the intended shape for the untracked host-specific part.
+
+### SSH
+Shared SSH defaults are managed in `ssh/config` and linked to `~/.ssh/config` by `init.zsh`. Keep host-specific entries in `~/.ssh/config.local`.
+
+To fully recreate a machine without putting server details in the public repository, keep a separate private overlay repository with files such as `zshrc.local` and `ssh/config.local`. `init.zsh` links those files automatically from `~/work/dotfiles-private` by default, or from `$DOTFILES_PRIVATE_DIR` if set.
+
 ### Tmux
 tmux is automatically started whenever a terminal is opened.
+
+### Ghostty
+Ghostty terminal settings are managed in `ghostty/config.ghostty` and linked to both `~/.config/ghostty/config.ghostty` and `~/.config/ghostty/config` by `init.zsh` so Ghostty and cmux read the same file.
 
 ### VS Code
 VS Code configuration files are also included. The `vscode/` directory contains editor settings and recommended extensions, allowing you to quickly set up a comfortable development environment in VS Code.

--- a/ghostty/config.ghostty
+++ b/ghostty/config.ghostty
@@ -1,0 +1,4 @@
+font-family = UDEV Gothic 35NF
+
+# Make Ctrl+M send a carriage return explicitly inside cmux/Ghostty terminals.
+keybind = ctrl+m=text:\x0d

--- a/init.zsh
+++ b/init.zsh
@@ -77,8 +77,12 @@ backup_existing() {
 
 
 setup_git_submodule() {
-    git submodule update --init --recursive && \
-    success "git submodule update --init --recursive"
+    if git submodule update --init --recursive; then
+        success "git submodule update --init --recursive"
+    else
+        error "Failed to initialize git submodules"
+        exit 1
+    fi
 }
 
 
@@ -102,6 +106,7 @@ install_deno() {
 
 install_dotfiles() {
     info "Installing dotfiles..."
+    local private_dotfiles_dir="${DOTFILES_PRIVATE_DIR:-$HOME/work/dotfiles-private}"
 
     # https://github.com/sorin-ionescu/prezto
     link_files `pwd`/zprezto ~/.zprezto
@@ -116,6 +121,25 @@ install_dotfiles() {
     link_files `pwd`/vim ~/.vim
     link_files `pwd`/zshrc ~/.zshrc
     link_files `pwd`/zpreztorc ~/.zpreztorc
+    if [ -d "$private_dotfiles_dir" ]; then
+        if [ -f "$private_dotfiles_dir/zshrc.local" ]; then
+            link_files "$private_dotfiles_dir/zshrc.local" ~/.zshrc.local
+        else
+            warn "Private zsh overlay not found at $private_dotfiles_dir/zshrc.local. Skipping."
+        fi
+    fi
+    mkdir -p ~/.ssh
+    link_files `pwd`/ssh/config ~/.ssh/config
+    if [ -d "$private_dotfiles_dir" ]; then
+        if [ -f "$private_dotfiles_dir/ssh/config.local" ]; then
+            link_files "$private_dotfiles_dir/ssh/config.local" ~/.ssh/config.local
+        else
+            warn "Private SSH overlay not found at $private_dotfiles_dir/ssh/config.local. Skipping."
+        fi
+    fi
+    mkdir -p ~/.config/ghostty
+    link_files `pwd`/ghostty/config.ghostty ~/.config/ghostty/config.ghostty
+    link_files `pwd`/ghostty/config.ghostty ~/.config/ghostty/config
 
     # VS Code settings (macOS specific)
     if [[ "$(uname)" == "Darwin" ]]; then

--- a/ssh/config
+++ b/ssh/config
@@ -1,0 +1,7 @@
+Host *
+  ServerAliveInterval 60
+  ForwardAgent yes
+  IdentityFile ~/.ssh/id_rsa
+  AddKeysToAgent yes
+
+Include ~/.ssh/config.local

--- a/ssh/config.local.example
+++ b/ssh/config.local.example
@@ -1,0 +1,14 @@
+# Copy host-specific entries here if you split SSH settings into:
+#   public repo:  ssh/config
+#   private repo: ssh/config.local
+#
+# `init.zsh` links the private file to ~/.ssh/config.local when it exists in
+# ~/work/dotfiles-private or $DOTFILES_PRIVATE_DIR.
+
+Host remote-gpu
+  HostName example-host
+  User example-user
+  Port 22
+  IdentityFile ~/.ssh/id_ed25519
+  IdentitiesOnly yes
+  ProxyCommand /path/to/ssh-proxy %h %p

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -40,11 +40,14 @@
   "files.autoSave": "onFocusChange",
   // フォーマッタ（好みに合わせて変更）
   "editor.formatOnSave": true,
+  "[latex]": {
+    "editor.formatOnSave": false
+  },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[python]": {
-    "editor.defaultFormatter": "ms-python.black-formatter"
+    "editor.defaultFormatter": "ms-python.black-formatter",
     "editor.tabSize": 4,
     "editor.insertSpaces": true,
     // detectIndentation を無効にするとファイル中の既存インデントに引きずられません
@@ -53,6 +56,13 @@
   // ターミナル
   "terminal.integrated.fontSize": 13,
   "terminal.integrated.shellIntegration.enabled": true,
+  "terminal.integrated.defaultProfile.linux": "zsh",
+  "terminal.integrated.profiles.linux": {
+    "zsh": {
+      "path": "/usr/bin/zsh"
+    }
+  },
+  "terminal.integrated.suggest.enabled": false,
   // 拡張機能・UI
   "workbench.startupEditor": "none",
   "workbench.colorTheme": "Gruvbox Dark Medium",

--- a/zpreztorc
+++ b/zpreztorc
@@ -93,8 +93,14 @@ zstyle ':prezto:module:git:status:ignore' submodules 'all'
 # History
 #
 
+# Keep using the main history file when cmux points ZDOTDIR at a relay dir.
+_prezto_histfile="${ZDOTDIR:-$HOME}/.zsh_history"
+if [[ -n "${ZDOTDIR:-}" && "$ZDOTDIR" == "$HOME/.cmux/relay/"* ]]; then
+  _prezto_histfile="$HOME/.zsh_history"
+fi
+
 # Set the file to save the history in when an interactive shell exits.
-zstyle ':prezto:module:history' histfile "${ZDOTDIR:-$HOME}/.zsh_history"
+zstyle ':prezto:module:history' histfile "$_prezto_histfile"
 
 # Set the maximum  number  of  events  stored  in  the  internal history list.
 zstyle ':prezto:module:history' histsize 10000

--- a/zshrc
+++ b/zshrc
@@ -12,15 +12,30 @@ eval "$(pyenv init --path)"
 export DENO_INSTALL=$HOME/.deno
 export PATH="$DENO_INSTALL/bin:$PATH"
 
-source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"
+if [[ -n "${ZDOTDIR:-}" && "$ZDOTDIR" == "$HOME/.cmux/relay/"* && -d "$ZDOTDIR" ]]; then
+  [[ -e "$ZDOTDIR/.zpreztorc" ]] || ln -s "$HOME/.zpreztorc" "$ZDOTDIR/.zpreztorc" 2>/dev/null
+  if [[ -e "$HOME/.p10k.zsh" && ! -e "$ZDOTDIR/.p10k.zsh" ]]; then
+    ln -s "$HOME/.p10k.zsh" "$ZDOTDIR/.p10k.zsh" 2>/dev/null
+  fi
+fi
+
+if [[ -r "${ZDOTDIR:-$HOME}/.zprezto/init.zsh" ]]; then
+  source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"
+elif [[ -r "$HOME/.zprezto/init.zsh" ]]; then
+  source "$HOME/.zprezto/init.zsh"
+fi
 
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
-# The next line updates PATH for the Google Cloud SDK.
-if [ -f '/Users/01047926/Downloads/google-cloud-sdk/path.zsh.inc' ]; then . '/Users/01047926/Downloads/google-cloud-sdk/path.zsh.inc'; fi
-
-# The next line enables shell command completion for gcloud.
-if [ -f '/Users/01047926/Downloads/google-cloud-sdk/completion.zsh.inc' ]; then . '/Users/01047926/Downloads/google-cloud-sdk/completion.zsh.inc'; fi
-
 . "$HOME/.local/bin/env"
+
+# Load machine-specific overrides outside version control.
+typeset -g DOTFILES_ZSHRC_DIR="${${(%):-%N}:A:h}"
+for _dotfiles_local_zshrc in "$HOME/.zshrc.local" "$DOTFILES_ZSHRC_DIR/zshrc.local"; do
+  if [[ -r "$_dotfiles_local_zshrc" ]]; then
+    source "$_dotfiles_local_zshrc"
+    break
+  fi
+done
+unset _dotfiles_local_zshrc

--- a/zshrc.local.example
+++ b/zshrc.local.example
@@ -1,0 +1,33 @@
+# Keep machine-specific paths, secrets, and server shortcuts here.
+# Copy this to:
+#   ~/work/dotfiles-private/zshrc.local
+# or:
+#   ~/.zshrc.local
+#
+# `init.zsh` links the private-repo variant automatically when it exists.
+
+# Example: initialize a local Google Cloud SDK install.
+# if [[ -f "$HOME/Downloads/google-cloud-sdk/path.zsh.inc" ]]; then
+#   source "$HOME/Downloads/google-cloud-sdk/path.zsh.inc"
+# fi
+# if [[ -f "$HOME/Downloads/google-cloud-sdk/completion.zsh.inc" ]]; then
+#   source "$HOME/Downloads/google-cloud-sdk/completion.zsh.inc"
+# fi
+
+# Example: secrets belong in a local-only file or secret manager.
+# export OPENAI_API_KEY="..."
+# export LANGCHAIN_API_KEY="..."
+
+# Keep real server definitions out of this file.
+# Define SSH host aliases in ~/.ssh/config or ~/.ssh/config.local instead.
+#
+# If you still want a zsh shorthand, keep it here and reference the SSH alias:
+# cmux() {
+#   if [[ "$1" == "ssh" && "$2" == "remote-gpu" ]]; then
+#     shift 2
+#     command cmux ssh remote-gpu --name remote-gpu "$@"
+#     return $?
+#   fi
+#
+#   command cmux "$@"
+# }


### PR DESCRIPTION
## Summary
- split shared dotfiles from private local settings
- add tracked Ghostty and SSH config with local overlays
- ignore generated dein cache files
- tidy shared VS Code settings