### PR TITLE
docs: rewrite README and fix init paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,198 +1,111 @@
 # Dotfiles
 
 [![CI](https://github.com/tma15/dotfiles/workflows/CI/badge.svg)](https://github.com/tma15/dotfiles/actions/workflows/ci.yaml)
-[![tagpr](https://github.com/tma15/dotfiles/workflows/tagpr/badge.svg)](https://github.com/tma15/dotfiles/actions/workflows/tagpr.yaml)
-[![Security Check](https://github.com/tma15/dotfiles/workflows/Security%20and%20Dependency%20Check/badge.svg)](https://github.com/tma15/dotfiles/actions/workflows/security-check.yaml)
-[![Submodule Update](https://github.com/tma15/dotfiles/workflows/Submodule%20Update%20Check/badge.svg)](https://github.com/tma15/dotfiles/actions/workflows/submodule-update.yaml)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/tma15/dotfiles)](https://github.com/tma15/dotfiles/releases)
 [![License](https://img.shields.io/github/license/tma15/dotfiles)](https://github.com/tma15/dotfiles/blob/main/LICENSE)
-[![GitHub last commit](https://img.shields.io/github/last-commit/tma15/dotfiles)](https://github.com/tma15/dotfiles/commits/main)
 
-The dotfiles repository contains configuration files for the following tools:
+Personal dotfiles for shell, editor, terminal, and SSH setup on macOS and Linux.
 
-- SSH
-- tmux
-- vim
-- zsh
-- Ghostty
-- VS Code
+Managed configs:
 
-## Install
+- `zsh`
+- `vim`
+- `tmux`
+- `ssh`
+- `Ghostty`
+- `VS Code`
+
+## Quick Start
 
 ### Requirements
-- macOS or Linux
-- Git
-- Zsh (will be configured automatically)
 
-### Installation
+- macOS or Linux
+- `git`
+- `curl`
+- `zsh`
+
+### Install
+
 ```sh
 git clone https://github.com/tma15/dotfiles.git
 cd dotfiles
 zsh init.zsh
 ```
 
-**Note**: The installation script will automatically install Deno and configure symbolic links.
-If you split private settings into a separate repository, place it at `~/work/dotfiles-private` or set `DOTFILES_PRIVATE_DIR` before running `init.zsh`.
+`init.zsh` initializes submodules, backs up existing files when needed, creates
+symlinks, and installs Deno if `$HOME/.deno/bin/deno` does not exist. Existing
+files are backed up as `*.backup.<timestamp>`.
 
-## Features
-### Vim
-The vim configuration manages plugins via [dein](https://github.com/Shougo/dein.vim).
-On the first launch, dein installs plugins defined in `vim/dein/userconfig/plugins.toml` and `vim/dein/userconfig/plugins_lazy.toml`.
+## Local Overrides
 
-Modern plugins such as [ddc](https://github.com/Shougo/ddc.vim) and [vim-lsp](https://github.com/prabirshrestha/vim-lsp) are included for code completion.
-Since ddc depends on [Deno](https://deno.land/), it will be installed by `init.zsh`.
+Keep machine-specific values out of the repository.
 
-Dein also installs plugins like [black](https://github.com/psf/black) and [vim-indent-guide](https://github.com/thaerkh/vim-indentguides) to assist with Python development.
-Additionally, a [flake8](https://flake8.pycqa.org/en/latest/)-based linter is enabled via `vim-lsp`.
+- `~/.zshrc.local` for local paths, SDK setup, and secrets
+- `~/.ssh/config.local` for host-specific SSH entries
+- `zshrc.local.example` and `ssh/config.local.example` as templates
+
+If you keep private files in a separate repository, place it at
+`~/work/dotfiles-private` or set `DOTFILES_PRIVATE_DIR` before running
+`init.zsh`.
+
+When that overlay repository exists, `init.zsh` links:
+
+- `zshrc.local` to `~/.zshrc.local`
+- `ssh/config.local` to `~/.ssh/config.local`
+
+## Managed Files
 
 ### Zsh
-The zsh configuration is based on [prezto](https://github.com/sorin-ionescu/prezto), with the main settings in `zpreztorc`.
 
-The Python environment is managed by [pyenv](https://github.com/pyenv/pyenv), with its configuration in `zshrc`.
+- `zprezto` is included as a git submodule
+- Main shell settings live in `zpreztorc`
+- `zshrc` sets up `pyenv`, Deno, Prezto, and local overrides
+- `zshrc` loads `~/.zshrc.local` first, then a repo-local `zshrc.local` if present
 
-Keep `zshrc` portable and put machine-specific values in `~/.zshrc.local` (recommended) or `zshrc.local` next to the repository copy of `zshrc`. Use it for local SDK paths and API keys; `zshrc.local.example` shows the expected shape.
+### Vim
 
-For remote access, define host aliases in `~/.ssh/config.local` so `cmux ssh <alias>` works without a shell wrapper. The tracked `ssh/config` contains shared defaults and includes the local file; `ssh/config.local.example` shows the intended shape for the untracked host-specific part.
+- Plugins are managed by `dein`
+- Plugin lists live in `vim/dein/userconfig/plugins.toml` and
+  `vim/dein/userconfig/plugins_lazy.toml`
+- Deno-backed completion plugins are supported, so `init.zsh` installs Deno
 
 ### SSH
-Shared SSH defaults are managed in `ssh/config` and linked to `~/.ssh/config` by `init.zsh`. Keep host-specific entries in `~/.ssh/config.local`.
 
-To fully recreate a machine without putting server details in the public repository, keep a separate private overlay repository with files such as `zshrc.local` and `ssh/config.local`. `init.zsh` links those files automatically from `~/work/dotfiles-private` by default, or from `$DOTFILES_PRIVATE_DIR` if set.
+- Shared defaults live in `ssh/config`
+- `ssh/config` includes `~/.ssh/config.local`
+- Public defaults and private host aliases stay separate
 
-### Tmux
-tmux is automatically started whenever a terminal is opened.
+### tmux
+
+- `tmux.conf` is installed by `init.zsh`
+- tmux auto-start is currently disabled in `zpreztorc`
 
 ### Ghostty
-Ghostty terminal settings are managed in `ghostty/config.ghostty` and linked to both `~/.config/ghostty/config.ghostty` and `~/.config/ghostty/config` by `init.zsh` so Ghostty and cmux read the same file.
+
+- `ghostty/config.ghostty` is linked to both
+  `~/.config/ghostty/config.ghostty` and `~/.config/ghostty/config`
 
 ### VS Code
-VS Code configuration files are also included. The `vscode/` directory contains editor settings and recommended extensions, allowing you to quickly set up a comfortable development environment in VS Code.
 
-## Development
+- `vscode/settings.json` and `vscode/keybindings.json` are included
+- `init.zsh` links them on macOS when the VS Code user settings directory exists
 
-### Version Management
-This repository uses [tagpr](https://github.com/Songmu/tagpr) for automatic version management and release creation.
+## Updating
 
-#### How to update version
-1. **Make changes** to dotfiles configuration
-2. **Create a pull request** with your changes
-3. **Add version labels** to the PR:
-   - `major`: for breaking changes (e.g., major configuration restructure)
-   - `minor`: for new features (e.g., new tool configuration)
-   - No label: for patch updates (e.g., bug fixes, minor tweaks)
-4. **Merge the PR** to the main branch
+After pulling new changes, update submodules and re-run setup if needed.
 
-#### What happens automatically
-- tagpr creates a release PR with updated `VERSION` file and `CHANGELOG.md`
-- When the release PR is merged:
-  - Git tag is created (e.g., `v1.2.3`)
-  - GitHub Release is published
-  - Version files are synchronized
-
-#### Manual version update (if needed)
-If you need to manually update the version:
-```bash
-# Edit VERSION file
-echo "1.2.3" > VERSION
-
-# Commit and push
-git add VERSION
-git commit -m "bump version to 1.2.3"
-git push
-```
-
-### CI/CD
-The repository includes comprehensive GitHub Actions workflows for automation and quality assurance:
-
-#### Core Workflows
-- **CI** (`ci.yaml`): 
-  - Tests syntax and installation on Ubuntu/macOS
-  - Validates configuration files and dependencies
-  - Checks for code quality issues (trailing whitespace, line endings)
-  - Verifies submodule integrity and symlink health
-- **tagpr** (`tagpr.yaml`): Automatic version management and releases
-
-#### Automated Maintenance
-- **Submodule Update Check** (`submodule-update.yaml`):
-  - Runs weekly (Monday 9:00 AM UTC)
-  - Automatically checks for new pyenv releases and zprezto updates
-  - Creates pull requests when updates are available
-  - Includes proper labeling for dependency updates
-- **Security & Dependency Check** (`security-check.yaml`):
-  - Runs weekly (Tuesday 2:00 AM UTC)
-  - Scans for security vulnerabilities using Trivy
-  - Checks for outdated tools (Deno, GitHub Actions)
-  - Validates license compliance across submodules
-  - Reports results to GitHub Security tab
-
-#### Manual Triggers
-All automated workflows can be manually triggered via GitHub Actions interface for immediate checks when needed.
-
-#### Workflow Badges
-You can monitor the status of these workflows through the badges at the top of this README:
-- CI status shows the health of the latest tests
-- tagpr status indicates the state of version management
-- Additional workflow statuses can be viewed in the Actions tab
-
-#### Security Features
-- **Vulnerability Scanning**: Automated security scans with results uploaded to GitHub Security tab
-- **Dependency Review**: Automatic review of dependency changes in pull requests
-- **License Compliance**: Regular checks to ensure all components maintain proper licensing
-
-### Submodule Management
-This repository uses git submodules for `pyenv` and `zprezto`.
-
-#### After Pulling Latest Changes
-When you pull the latest changes from the repository, submodules are **not automatically updated**. You need to explicitly update them:
-
-```bash
-# After git pull
+```sh
 git pull origin main
-
-# Update submodules to match the repository's recorded versions
 git submodule update --init --recursive
-```
-
-Or simply re-run the setup script (recommended):
-```bash
 zsh init.zsh
 ```
 
-**Important**: The automated CI workflow creates PRs for submodule updates weekly. After merging these PRs, you must run `git submodule update --init --recursive` locally to apply the updates to your environment.
+## Maintenance
 
-#### Manually Updating Submodules
-To update submodules to newer versions:
-
-```bash
-# Update all submodules to latest
-git submodule update --remote
-
-# Update specific submodule (pyenv to specific version)
-cd pyenv
-git fetch --tags --all  # Ensure all tags are available
-git tag --list | grep -E '^v[0-9]+\.' | tail -5  # Check available versions
-git checkout v2.6.10  # or latest version (check above command output)
-cd ..
-git add pyenv
-git commit -m "chore: update pyenv to v2.6.10"
-
-# Update zprezto submodule (typically stays on master)
-cd zprezto
-git checkout master
-git pull origin master
-cd ..
-git add zprezto
-git commit -m "chore: update zprezto to latest master"
-
-# Check submodule status
-git submodule status
-```
-
-**Note**: 
-- `pyenv` uses semantic versioning tags (e.g., v2.6.10)
-- `zprezto` typically uses the master branch
-- Always commit submodule updates to track the specific versions used
-- New Python versions (3.13.x, etc.) require updating pyenv to the latest release
+- Releases are managed with `tagpr`
+- GitHub Actions workflows live in `.github/workflows/`
+- Weekly workflows check submodule updates and security/dependency issues
 
 ## Author
+
 Takuya Makino

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,7 @@
 #!/bin/zsh
 
+typeset -gr DOTFILES_DIR="${${(%):-%N}:A:h}"
+
 success() {
     printf "\r\033[2K  [ \033[00;32mOK\033[0m ] $1\n"
 }
@@ -61,23 +63,25 @@ check_os_compatibility() {
 }
 
 backup_existing() {
-    if [ -e $2 ] || [ -L $2 ]; then
-        local backup_name="$2.backup.$(date +%Y%m%d_%H%M%S)"
-        if [ -L $2 ]; then
+    local target="$2"
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        local backup_name="$target.backup.$(date +%Y%m%d_%H%M%S)"
+        if [ -L "$target" ]; then
             # If it's a symlink, just remove it
-            rm $2
-            info "Removed existing symlink: $2"
+            rm -- "$target"
+            info "Removed existing symlink: $target"
         else
             # If it's a regular file/directory, back it up
-            mv $2 "$backup_name"
-            info "Backed up existing $2 to $backup_name"
+            mv -- "$target" "$backup_name"
+            info "Backed up existing $target to $backup_name"
         fi
     fi
 }
 
 
 setup_git_submodule() {
-    if git submodule update --init --recursive; then
+    if git -C "$DOTFILES_DIR" submodule update --init --recursive; then
         success "git submodule update --init --recursive"
     else
         error "Failed to initialize git submodules"
@@ -87,8 +91,8 @@ setup_git_submodule() {
 
 
 link_files() {
-    backup_existing $1 $2
-    ln -ns $1 $2 && success "linked $1 to $2"
+    backup_existing "$1" "$2"
+    ln -ns "$1" "$2" && success "linked $1 to $2"
 }
 
 
@@ -109,18 +113,18 @@ install_dotfiles() {
     local private_dotfiles_dir="${DOTFILES_PRIVATE_DIR:-$HOME/work/dotfiles-private}"
 
     # https://github.com/sorin-ionescu/prezto
-    link_files `pwd`/zprezto ~/.zprezto
-    link_files `pwd`/zprezto/runcoms/zlogin ~/.zlogin
-    link_files `pwd`/zprezto/runcoms/zlogout ~/.zlogout
-    link_files `pwd`/zprezto/runcoms/zprofile ~/.zprofile
-    link_files `pwd`/zprezto/runcoms/zshenv ~/.zshenv
+    link_files "$DOTFILES_DIR/zprezto" ~/.zprezto
+    link_files "$DOTFILES_DIR/zprezto/runcoms/zlogin" ~/.zlogin
+    link_files "$DOTFILES_DIR/zprezto/runcoms/zlogout" ~/.zlogout
+    link_files "$DOTFILES_DIR/zprezto/runcoms/zprofile" ~/.zprofile
+    link_files "$DOTFILES_DIR/zprezto/runcoms/zshenv" ~/.zshenv
 
-    link_files `pwd`/pyenv ~/.pyenv
-    link_files `pwd`/tmux.conf ~/.tmux.conf
-    link_files `pwd`/vimrc ~/.vimrc
-    link_files `pwd`/vim ~/.vim
-    link_files `pwd`/zshrc ~/.zshrc
-    link_files `pwd`/zpreztorc ~/.zpreztorc
+    link_files "$DOTFILES_DIR/pyenv" ~/.pyenv
+    link_files "$DOTFILES_DIR/tmux.conf" ~/.tmux.conf
+    link_files "$DOTFILES_DIR/vimrc" ~/.vimrc
+    link_files "$DOTFILES_DIR/vim" ~/.vim
+    link_files "$DOTFILES_DIR/zshrc" ~/.zshrc
+    link_files "$DOTFILES_DIR/zpreztorc" ~/.zpreztorc
     if [ -d "$private_dotfiles_dir" ]; then
         if [ -f "$private_dotfiles_dir/zshrc.local" ]; then
             link_files "$private_dotfiles_dir/zshrc.local" ~/.zshrc.local
@@ -129,7 +133,7 @@ install_dotfiles() {
         fi
     fi
     mkdir -p ~/.ssh
-    link_files `pwd`/ssh/config ~/.ssh/config
+    link_files "$DOTFILES_DIR/ssh/config" ~/.ssh/config
     if [ -d "$private_dotfiles_dir" ]; then
         if [ -f "$private_dotfiles_dir/ssh/config.local" ]; then
             link_files "$private_dotfiles_dir/ssh/config.local" ~/.ssh/config.local
@@ -138,17 +142,15 @@ install_dotfiles() {
         fi
     fi
     mkdir -p ~/.config/ghostty
-    link_files `pwd`/ghostty/config.ghostty ~/.config/ghostty/config.ghostty
-    link_files `pwd`/ghostty/config.ghostty ~/.config/ghostty/config
+    link_files "$DOTFILES_DIR/ghostty/config.ghostty" ~/.config/ghostty/config.ghostty
+    link_files "$DOTFILES_DIR/ghostty/config.ghostty" ~/.config/ghostty/config
 
     # VS Code settings (macOS specific)
     if [[ "$(uname)" == "Darwin" ]]; then
         local vscode_dir="$HOME/Library/Application Support/Code/User"
         if [ -d "$vscode_dir" ]; then
-            backup_existing ~/work/dotfiles/vscode/settings.json "$vscode_dir/settings.json"
-            backup_existing ~/work/dotfiles/vscode/keybindings.json "$vscode_dir/keybindings.json"
-            ln -s ~/work/dotfiles/vscode/settings.json "$vscode_dir/settings.json"
-            ln -s ~/work/dotfiles/vscode/keybindings.json "$vscode_dir/keybindings.json"
+            link_files "$DOTFILES_DIR/vscode/settings.json" "$vscode_dir/settings.json"
+            link_files "$DOTFILES_DIR/vscode/keybindings.json" "$vscode_dir/keybindings.json"
             success "VS Code settings linked"
         else
             warn "VS Code directory not found. Skipping VS Code settings."


### PR DESCRIPTION
## Summary
- rewrite the README around quick start, local overrides, managed files, and updating
- fix init.zsh to resolve repo paths from the script location instead of ~/work/dotfiles
- smoke test init.zsh in a temporary HOME and verify the created symlinks

## Testing
- zsh -n init.zsh
- git diff --check
- run init.zsh with a temporary HOME from /tmp and verify created symlinks