### PR TITLE
chore: tighten cmux shell setup and add smoke tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,9 @@ jobs:
         # Test zshrc syntax
         zsh -n zshrc
 
+        # Test zpreztorc syntax
+        zsh -n zpreztorc
+
     - name: Test vimrc syntax
       run: |
         # Install vim for syntax checking
@@ -61,23 +64,9 @@ jobs:
         # Test tmux config syntax
         tmux -f tmux.conf list-keys > /dev/null
 
-    - name: Test dotfiles installation (dry run)
+    - name: Run dotfiles smoke tests
       run: |
-        # Create a temporary directory to test installation
-        mkdir -p /tmp/dotfiles-test
-        export HOME=/tmp/dotfiles-test
-        
-        # Test git submodule update
-        git submodule update --init --recursive
-        
-        # Test that files exist
-        test -f vimrc
-        test -f zshrc
-        test -f tmux.conf
-        test -f zpreztorc
-        test -d vim
-        test -d zprezto
-        test -d pyenv
+        zsh test/run.zsh
 
     - name: Test file permissions
       run: |
@@ -109,6 +98,12 @@ jobs:
         # Lint zshrc (skip shellcheck for zsh-specific syntax)
         echo "Checking zshrc syntax with zsh..."
         zsh -n zshrc
+
+        echo "Checking zpreztorc syntax with zsh..."
+        zsh -n zpreztorc
+
+        echo "Checking test scripts syntax with zsh..."
+        find test -name "*.zsh" -exec zsh -n {} \;
         
         # Lint any bash scripts if they exist
         if find . -name "*.sh" -o -name "*.bash" | grep -q .; then

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ When that overlay repository exists, `init.zsh` links:
 - Main shell settings live in `zpreztorc`
 - `zshrc` sets up `pyenv`, Deno, Prezto, and local overrides
 - `zshrc` loads `~/.zshrc.local` first, then a repo-local `zshrc.local` if present
+- For cmux relay behavior and SSH alias setup, see `docs/cmux.md`
 
 ### Vim
 
@@ -73,12 +74,12 @@ When that overlay repository exists, `init.zsh` links:
 
 - Shared defaults live in `ssh/config`
 - `ssh/config` includes `~/.ssh/config.local`
-- Public defaults and private host aliases stay separate
+- Public defaults stay in `ssh/config`; identities, forwarding, and host aliases stay local
 
 ### tmux
 
 - `tmux.conf` is installed by `init.zsh`
-- tmux auto-start is currently disabled in `zpreztorc`
+- tmux is kept as an explicit fallback; Prezto tmux auto-start and aliases are disabled
 
 ### Ghostty
 
@@ -105,6 +106,7 @@ zsh init.zsh
 - Releases are managed with `tagpr`
 - GitHub Actions workflows live in `.github/workflows/`
 - Weekly workflows check submodule updates and security/dependency issues
+- Run local smoke tests with `zsh test/run.zsh`
 
 ## Author
 

--- a/docs/cmux.md
+++ b/docs/cmux.md
@@ -1,0 +1,31 @@
+# cmux Notes
+
+This repository treats `cmux` as the primary entry point for relay and remote
+shells. `tmux` remains available as an explicit fallback, but the shell setup is
+biased toward `cmux`.
+
+## Relay Shells
+
+- `zshrc` treats a shell as a cmux relay when `ZDOTDIR` is under
+  `~/.cmux/relay/`
+- Relay shells keep using `~/.zsh_history` instead of a relay-local history file
+- `zshrc` makes sure `.zpreztorc` and `.p10k.zsh` are reachable inside the relay
+  directory
+
+## SSH Aliases
+
+- Define real hosts in `~/.ssh/config.local`
+- Run `cmux ssh <alias>` instead of wrapping SSH targets in shell functions
+- Keep `IdentityFile`, `ForwardAgent`, `ProxyCommand`, and similar options scoped
+  to the hosts that need them
+
+## Ghostty
+
+- `ghostty/config.ghostty` maps `Ctrl+M` to a carriage return explicitly for
+  cmux and Ghostty sessions
+
+## tmux Fallback
+
+- `tmux.conf` stays in the repository for direct tmux use
+- Prezto tmux auto-start is disabled
+- Prezto tmux aliases are disabled so `cmux` stays the default entry point

--- a/init.zsh
+++ b/init.zsh
@@ -162,14 +162,19 @@ install_dotfiles() {
     success "Dotfiles installation completed"
 }
 
-# Main execution
-info "Starting dotfiles installation..."
+main() {
+    info "Starting dotfiles installation..."
 
-check_dependencies
-check_os_compatibility
-setup_git_submodule
-install_dotfiles
+    check_dependencies
+    check_os_compatibility
+    setup_git_submodule
+    install_dotfiles
 
-if [ ! -e $HOME/.deno/bin/deno ]; then
-    install_deno
+    if [ ! -e "$HOME/.deno/bin/deno" ]; then
+        install_deno
+    fi
+}
+
+if [[ -z "${DOTFILES_SOURCE_ONLY:-}" && "${${(%):-%N}:A}" == "${0:A}" ]]; then
+    main "$@"
 fi

--- a/ssh/config
+++ b/ssh/config
@@ -1,7 +1,8 @@
+Include ~/.ssh/config.local
+
 Host *
   ServerAliveInterval 60
-  ForwardAgent yes
-  IdentityFile ~/.ssh/id_rsa
   AddKeysToAgent yes
+  ForwardAgent no
 
-Include ~/.ssh/config.local
+# Keep host-specific identities, agent forwarding, and proxies in the local file.

--- a/ssh/config.local.example
+++ b/ssh/config.local.example
@@ -4,6 +4,9 @@
 #
 # `init.zsh` links the private file to ~/.ssh/config.local when it exists in
 # ~/work/dotfiles-private or $DOTFILES_PRIVATE_DIR.
+#
+# Keep identities, agent forwarding, and proxies scoped to the hosts that need
+# them instead of setting them globally.
 
 Host remote-gpu
   HostName example-host
@@ -11,4 +14,5 @@ Host remote-gpu
   Port 22
   IdentityFile ~/.ssh/id_ed25519
   IdentitiesOnly yes
+  ForwardAgent yes
   ProxyCommand /path/to/ssh-proxy %h %p

--- a/test/lib.zsh
+++ b/test/lib.zsh
@@ -1,0 +1,71 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+typeset -gr TEST_DIR="${${(%):-%N}:A:h}"
+typeset -gr REPO_ROOT="${TEST_DIR:h}"
+typeset -ga TEST_TMPDIRS=()
+
+make_temp_dir() {
+  local prefix="${1:-dotfiles-test}"
+  local tmpdir
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/${prefix}.XXXXXX")"
+  TEST_TMPDIRS+=("$tmpdir")
+  print -r -- "$tmpdir"
+}
+
+cleanup_temp_dirs() {
+  local tmpdir
+
+  for tmpdir in "${TEST_TMPDIRS[@]}"; do
+    [[ -d "$tmpdir" ]] && rm -rf -- "$tmpdir"
+  done
+}
+
+fail() {
+  print -u2 -- "FAIL: $1"
+  exit 1
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="${3:-expected '$expected', got '$actual'}"
+
+  [[ "$actual" == "$expected" ]] || fail "$message"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local message="${3:-expected output to contain '$needle'}"
+
+  [[ "$haystack" == *"$needle"* ]] || fail "$message"
+}
+
+assert_exists() {
+  local path="$1"
+
+  [[ -e "$path" || -L "$path" ]] || fail "expected '$path' to exist"
+}
+
+assert_not_exists() {
+  local path="$1"
+
+  [[ ! -e "$path" && ! -L "$path" ]] || fail "expected '$path' to not exist"
+}
+
+assert_symlink_target() {
+  local path="$1"
+  local expected="$2"
+  local actual
+  local expected_abs
+
+  [[ -L "$path" ]] || fail "expected '$path' to be a symlink"
+  actual="${path:A}"
+  expected_abs="${expected:A}"
+  [[ "$actual" == "$expected_abs" ]] || fail "expected '$path' to point to '$expected_abs', got '$actual'"
+}
+
+trap cleanup_temp_dirs EXIT

--- a/test/run.zsh
+++ b/test/run.zsh
@@ -1,0 +1,10 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+typeset -gr TEST_DIR="${${(%):-%N}:A:h}"
+
+for test_script in "$TEST_DIR"/test-*.zsh; do
+  print -r -- "==> ${test_script:t}"
+  /bin/zsh "$test_script"
+done

--- a/test/test-init.zsh
+++ b/test/test-init.zsh
@@ -1,0 +1,88 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+source "${0:A:h}/lib.zsh"
+
+[[ -d "$REPO_ROOT/pyenv" ]] || fail "pyenv submodule is missing"
+[[ -d "$REPO_ROOT/zprezto" ]] || fail "zprezto submodule is missing"
+
+tmp_home="$(make_temp_dir dotfiles-init-home)"
+private_dir="$(make_temp_dir dotfiles-private)"
+
+mkdir -p "$tmp_home/.deno/bin" "$tmp_home/.ssh" "$tmp_home/.config/ghostty" "$private_dir/ssh"
+print -r -- '#!/bin/sh' > "$tmp_home/.deno/bin/deno"
+print -r -- 'exit 0' >> "$tmp_home/.deno/bin/deno"
+chmod +x "$tmp_home/.deno/bin/deno"
+
+print -r -- 'legacy zshrc' > "$tmp_home/.zshrc"
+print -r -- 'legacy ssh config' > "$tmp_home/.ssh/config"
+print -r -- 'export DOTFILES_PRIVATE_TEST=1' > "$private_dir/zshrc.local"
+print -r -- 'Host private-host' > "$private_dir/ssh/config.local"
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  mkdir -p "$tmp_home/Library/Application Support/Code/User"
+  print -r -- '{}' > "$tmp_home/Library/Application Support/Code/User/settings.json"
+  print -r -- '[]' > "$tmp_home/Library/Application Support/Code/User/keybindings.json"
+fi
+
+(
+  cd "$tmp_home"
+  HOME="$tmp_home" DOTFILES_PRIVATE_DIR="$private_dir" /bin/zsh -fc '
+    export DOTFILES_SOURCE_ONLY=1
+    source "$1/init.zsh"
+    setup_git_submodule() { :; }
+    main
+  ' _ "$REPO_ROOT"
+)
+
+assert_symlink_target "$tmp_home/.zprezto" "$REPO_ROOT/zprezto"
+assert_symlink_target "$tmp_home/.pyenv" "$REPO_ROOT/pyenv"
+assert_symlink_target "$tmp_home/.zshrc" "$REPO_ROOT/zshrc"
+assert_symlink_target "$tmp_home/.zpreztorc" "$REPO_ROOT/zpreztorc"
+assert_symlink_target "$tmp_home/.vimrc" "$REPO_ROOT/vimrc"
+assert_symlink_target "$tmp_home/.tmux.conf" "$REPO_ROOT/tmux.conf"
+assert_symlink_target "$tmp_home/.ssh/config" "$REPO_ROOT/ssh/config"
+assert_symlink_target "$tmp_home/.config/ghostty/config.ghostty" "$REPO_ROOT/ghostty/config.ghostty"
+assert_symlink_target "$tmp_home/.config/ghostty/config" "$REPO_ROOT/ghostty/config.ghostty"
+assert_symlink_target "$tmp_home/.zshrc.local" "$private_dir/zshrc.local"
+assert_symlink_target "$tmp_home/.ssh/config.local" "$private_dir/ssh/config.local"
+
+zshrc_backups=("$tmp_home"/.zshrc.backup.*(N))
+ssh_config_backups=("$tmp_home"/.ssh/config.backup.*(N))
+assert_eq "${#zshrc_backups[@]}" "1" "expected one .zshrc backup after the first install"
+assert_eq "${#ssh_config_backups[@]}" "1" "expected one SSH config backup after the first install"
+assert_contains "$(cat "$zshrc_backups[1]")" "legacy zshrc"
+assert_contains "$(cat "$ssh_config_backups[1]")" "legacy ssh config"
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  assert_symlink_target "$tmp_home/Library/Application Support/Code/User/settings.json" "$REPO_ROOT/vscode/settings.json"
+  assert_symlink_target "$tmp_home/Library/Application Support/Code/User/keybindings.json" "$REPO_ROOT/vscode/keybindings.json"
+
+  vscode_settings_backups=("$tmp_home"/Library/Application\ Support/Code/User/settings.json.backup.*(N))
+  vscode_keybindings_backups=("$tmp_home"/Library/Application\ Support/Code/User/keybindings.json.backup.*(N))
+  assert_eq "${#vscode_settings_backups[@]}" "1" "expected one VS Code settings backup after the first install"
+  assert_eq "${#vscode_keybindings_backups[@]}" "1" "expected one VS Code keybindings backup after the first install"
+fi
+
+(
+  cd "$tmp_home"
+  HOME="$tmp_home" DOTFILES_PRIVATE_DIR="$private_dir" /bin/zsh -fc '
+    export DOTFILES_SOURCE_ONLY=1
+    source "$1/init.zsh"
+    setup_git_submodule() { :; }
+    main
+  ' _ "$REPO_ROOT"
+)
+
+zshrc_backups=("$tmp_home"/.zshrc.backup.*(N))
+ssh_config_backups=("$tmp_home"/.ssh/config.backup.*(N))
+assert_eq "${#zshrc_backups[@]}" "1" "expected .zshrc backups to stay stable across repeated installs"
+assert_eq "${#ssh_config_backups[@]}" "1" "expected SSH config backups to stay stable across repeated installs"
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  vscode_settings_backups=("$tmp_home"/Library/Application\ Support/Code/User/settings.json.backup.*(N))
+  vscode_keybindings_backups=("$tmp_home"/Library/Application\ Support/Code/User/keybindings.json.backup.*(N))
+  assert_eq "${#vscode_settings_backups[@]}" "1" "expected VS Code settings backups to stay stable across repeated installs"
+  assert_eq "${#vscode_keybindings_backups[@]}" "1" "expected VS Code keybindings backups to stay stable across repeated installs"
+fi

--- a/test/test-ssh-config.zsh
+++ b/test/test-ssh-config.zsh
@@ -1,0 +1,35 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+source "${0:A:h}/lib.zsh"
+
+tmpdir="$(make_temp_dir dotfiles-ssh-config)"
+rendered_config="$tmpdir/config"
+local_config="$tmpdir/config.local"
+
+sed "s|Include ~/.ssh/config.local|Include $local_config|" "$REPO_ROOT/ssh/config" > "$rendered_config"
+
+cat > "$local_config" <<'EOF'
+Host remote-gpu
+  HostName example-host
+  User example-user
+  Port 22
+  IdentityFile ~/.ssh/id_ed25519
+  IdentitiesOnly yes
+  ForwardAgent yes
+  ProxyCommand /path/to/ssh-proxy %h %p
+EOF
+
+generic_output="$(ssh -G generic-host -F "$rendered_config" 2>/dev/null)"
+remote_output="$(ssh -G remote-gpu -F "$rendered_config" 2>/dev/null)"
+
+assert_contains "$generic_output" $'serveraliveinterval 60'
+assert_contains "$generic_output" $'addkeystoagent true'
+assert_contains "$generic_output" $'forwardagent no'
+
+assert_contains "$remote_output" $'hostname example-host'
+assert_contains "$remote_output" $'user example-user'
+assert_contains "$remote_output" $'forwardagent yes'
+assert_contains "$remote_output" $'identityfile ~/.ssh/id_ed25519'
+assert_contains "$remote_output" $'proxycommand /path/to/ssh-proxy %h %p'

--- a/test/test-zsh-startup.zsh
+++ b/test/test-zsh-startup.zsh
@@ -1,0 +1,40 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+source "${0:A:h}/lib.zsh"
+
+plain_home="$(make_temp_dir dotfiles-zsh-plain)"
+mkdir -p "$plain_home/.zprezto"
+: > "$plain_home/.zprezto/init.zsh"
+
+HOME="$plain_home" ZDOTDIR="$plain_home" /bin/zsh -fc '
+  source "$1/zshrc"
+  [[ "${DOTFILES_IS_CMUX_RELAY:-0}" == "0" ]] || exit 1
+  [[ ! -e "$ZDOTDIR/.zpreztorc" ]] || exit 1
+' _ "$REPO_ROOT"
+
+relay_home="$(make_temp_dir dotfiles-zsh-relay)"
+mkdir -p "$relay_home/.zprezto" "$relay_home/.cmux/relay/session"
+: > "$relay_home/.zprezto/init.zsh"
+: > "$relay_home/.zpreztorc"
+: > "$relay_home/.p10k.zsh"
+
+HOME="$relay_home" ZDOTDIR="$relay_home/.cmux/relay/session" /bin/zsh -fc '
+  source "$1/zshrc"
+  source "$1/zpreztorc"
+
+  relay_zpreztorc="$ZDOTDIR/.zpreztorc"
+  relay_p10k="$ZDOTDIR/.p10k.zsh"
+  expected_zpreztorc="$HOME/.zpreztorc"
+  expected_p10k="$HOME/.p10k.zsh"
+  zstyle -s ":prezto:module:history" histfile histfile
+  zstyle -t ":prezto:module:tmux:alias" skip
+
+  [[ "${DOTFILES_IS_CMUX_RELAY:-0}" == "1" ]] || exit 1
+  [[ "$histfile" == "$HOME/.zsh_history" ]] || exit 1
+  [[ -L "$relay_zpreztorc" ]] || exit 1
+  [[ -L "$relay_p10k" ]] || exit 1
+  [[ "${relay_zpreztorc:A}" == "${expected_zpreztorc:A}" ]] || exit 1
+  [[ "${relay_p10k:A}" == "${expected_p10k:A}" ]] || exit 1
+' _ "$REPO_ROOT"

--- a/tmux.conf
+++ b/tmux.conf
@@ -6,9 +6,11 @@ bind-key C-t send-prefix
 set-window-option -g xterm-keys on
 
 ### Key mapping
-# split pane
-bind s split-window -v
-bind v split-window -h
+# split pane in the current directory
+bind s split-window -vc "#{pane_current_path}"
+bind v split-window -hc "#{pane_current_path}"
+# new window in the current directory
+bind c new-window -c "#{pane_current_path}"
 # move pane like vim
 bind j select-pane -D
 bind k select-pane -U
@@ -21,10 +23,6 @@ bind -r H resize-pane -L 5
 bind -r J resize-pane -D 5
 bind -r K resize-pane -U 5
 bind -r L resize-pane -R 5
-
-bind c new-window -c "#{pane_current_path}"
-bind v split-window -hc "#{pane_current_path}"
-bind s split-window -vc "#{pane_current_path}"
 
 ### 256 colors
 set-option -g default-terminal screen-256color

--- a/zpreztorc
+++ b/zpreztorc
@@ -95,7 +95,7 @@ zstyle ':prezto:module:git:status:ignore' submodules 'all'
 
 # Keep using the main history file when cmux points ZDOTDIR at a relay dir.
 _prezto_histfile="${ZDOTDIR:-$HOME}/.zsh_history"
-if [[ -n "${ZDOTDIR:-}" && "$ZDOTDIR" == "$HOME/.cmux/relay/"* ]]; then
+if [[ "${DOTFILES_IS_CMUX_RELAY:-0}" == '1' ]]; then
   _prezto_histfile="$HOME/.zsh_history"
 fi
 
@@ -231,6 +231,9 @@ zstyle ':prezto:module:syntax-highlighting' pattern \
 #
 # Tmux
 #
+
+# cmux is the primary multiplexer entry point. Keep Prezto tmux aliases disabled.
+zstyle ':prezto:module:tmux:alias' skip 'yes'
 
 # Auto start a session when Zsh is launched in a local terminal.
 zstyle ':prezto:module:tmux:auto-start' local 'no'

--- a/zshrc
+++ b/zshrc
@@ -5,19 +5,32 @@ if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]
   source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
 fi
 
+typeset -g DOTFILES_ZSHRC_DIR="${${(%):-%N}:A:h}"
+typeset -gi DOTFILES_IS_CMUX_RELAY=0
+
 export PYENV_ROOT="$HOME/.pyenv"
 [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init --path)"
+if (( $+commands[pyenv] )); then
+  eval "$(pyenv init --path)"
+fi
 
 export DENO_INSTALL=$HOME/.deno
 export PATH="$DENO_INSTALL/bin:$PATH"
 
+dotfiles_link_cmux_relay_file() {
+  local source="$1"
+  local target="$2"
+
+  [[ -e "$source" || -L "$source" ]] || return 0
+  ln -snf "$source" "$target" 2>/dev/null
+}
+
 if [[ -n "${ZDOTDIR:-}" && "$ZDOTDIR" == "$HOME/.cmux/relay/"* && -d "$ZDOTDIR" ]]; then
-  [[ -e "$ZDOTDIR/.zpreztorc" ]] || ln -s "$HOME/.zpreztorc" "$ZDOTDIR/.zpreztorc" 2>/dev/null
-  if [[ -e "$HOME/.p10k.zsh" && ! -e "$ZDOTDIR/.p10k.zsh" ]]; then
-    ln -s "$HOME/.p10k.zsh" "$ZDOTDIR/.p10k.zsh" 2>/dev/null
-  fi
+  DOTFILES_IS_CMUX_RELAY=1
+  dotfiles_link_cmux_relay_file "$HOME/.zpreztorc" "$ZDOTDIR/.zpreztorc"
+  dotfiles_link_cmux_relay_file "$HOME/.p10k.zsh" "$ZDOTDIR/.p10k.zsh"
 fi
+unset -f dotfiles_link_cmux_relay_file
 
 if [[ -r "${ZDOTDIR:-$HOME}/.zprezto/init.zsh" ]]; then
   source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"
@@ -28,10 +41,9 @@ fi
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
-. "$HOME/.local/bin/env"
+[[ -r "$HOME/.local/bin/env" ]] && . "$HOME/.local/bin/env"
 
 # Load machine-specific overrides outside version control.
-typeset -g DOTFILES_ZSHRC_DIR="${${(%):-%N}:A:h}"
 for _dotfiles_local_zshrc in "$HOME/.zshrc.local" "$DOTFILES_ZSHRC_DIR/zshrc.local"; do
   if [[ -r "$_dotfiles_local_zshrc" ]]; then
     source "$_dotfiles_local_zshrc"


### PR DESCRIPTION
## Summary
- tighten the cmux-oriented shell and tmux setup, including relay detection and tmux fallback behavior
- narrow global SSH defaults and document host-specific cmux/SSH guidance
- add repo-local smoke tests for init, zsh startup, and ssh config behavior, and run them in CI

## Testing
- zsh -n init.zsh zshrc zpreztorc test/*.zsh
- zsh test/run.zsh
- git diff --check