### PR TITLE
Fix Vim startup cache recovery

### DIFF
--- a/test/test-vim-startup.zsh
+++ b/test/test-vim-startup.zsh
@@ -1,0 +1,76 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+source "${0:A:h}/lib.zsh"
+
+skip() {
+  print -r -- "SKIP: $1"
+  exit 0
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local message="${3:-unexpected output contains '$needle'}"
+
+  [[ "$haystack" != *"$needle"* ]] || fail "$message"
+}
+
+typeset -r DEIN_REPOS_SOURCE="${DOTFILES_TEST_DEIN_REPOS:-$HOME/.vim/dein/repos}"
+typeset -r PYLSP_ALL_SOURCE="${DOTFILES_TEST_PYLSP_ALL:-$HOME/.local/share/vim-lsp-settings/servers/pylsp-all}"
+
+command -v vim >/dev/null 2>&1 || skip "vim is not installed"
+[[ -d "$DEIN_REPOS_SOURCE/github.com/Shougo/dein.vim" ]] || skip "dein repos are not available at $DEIN_REPOS_SOURCE"
+[[ -d "$PYLSP_ALL_SOURCE" ]] || skip "pylsp-all server is not available at $PYLSP_ALL_SOURCE"
+
+tmp_home="$(make_temp_dir dotfiles-vim-home)"
+mkdir -p \
+  "$tmp_home/.vim/dein" \
+  "$tmp_home/.local/share/vim-lsp-settings/servers"
+
+ln -s "$REPO_ROOT/vimrc" "$tmp_home/.vimrc"
+ln -s "$REPO_ROOT/vim/bin" "$tmp_home/.vim/bin"
+ln -s "$REPO_ROOT/vim/snippet" "$tmp_home/.vim/snippet"
+ln -s "$REPO_ROOT/vim/dein/userconfig" "$tmp_home/.vim/dein/userconfig"
+ln -s "$DEIN_REPOS_SOURCE" "$tmp_home/.vim/dein/repos"
+ln -s "$PYLSP_ALL_SOURCE" "$tmp_home/.local/share/vim-lsp-settings/servers/pylsp-all"
+
+typeset -r log_path="$tmp_home/vim.log"
+typeset -r messages_path="$tmp_home/messages.txt"
+
+typeset -a vim_args=(
+  -Nu NONE
+  -n
+  -i NONE
+  -es
+  --cmd 'set nocp'
+  --cmd 'let g:denops#disabled = 1'
+  --cmd 'set nomore'
+  "+source $tmp_home/.vimrc"
+  '+call dein#source()'
+  "+redir => g:msgs | silent messages | redir END | call writefile(split(g:msgs, \"\\n\"), '$messages_path')"
+  '+qall!'
+)
+
+if ! HOME="$tmp_home" vim "${vim_args[@]}" >"$log_path" 2>&1; then
+  print -u2 -- "vim startup test failed:"
+  sed -n '1,200p' "$log_path" >&2 || true
+  [[ -f "$messages_path" ]] && sed -n '1,200p' "$messages_path" >&2 || true
+  find "$tmp_home/.vim/dein" -maxdepth 3 -type f >&2 || true
+  fail "vim exited with a non-zero status"
+fi
+
+HOME="$tmp_home" "$REPO_ROOT/vim/bin/pylsp-all" --version >/dev/null 2>&1 \
+  || fail "pylsp-all wrapper did not start from the temp HOME"
+
+assert_exists "$tmp_home/.vim/dein/.cache/.vimrc/.dein/autoload/ddc.vim"
+assert_exists "$tmp_home/.vim/dein/.cache/.vimrc/.dein/autoload/lsp.vim"
+assert_exists "$tmp_home/.vim/dein/.cache/.vimrc/.dein/colors/molokai.vim"
+
+messages_content=""
+[[ -f "$messages_path" ]] && messages_content="$(<"$messages_path")"
+assert_not_contains "$messages_content" 'E185:' "colorscheme loading still fails"
+assert_not_contains "$messages_content" 'E117:' "ddc functions are still missing at startup"
+assert_not_contains "$messages_content" 'E631:' "LSP write failures are still happening"
+assert_not_contains "$messages_content" 'ch_sendraw()' "LSP channel writes are still failing"

--- a/vim/bin/pylsp-all
+++ b/vim/bin/pylsp-all
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+# Start pylsp from the vim-lsp-settings venv even if its interpreter symlink is stale.
+VENV="${HOME}/.local/share/vim-lsp-settings/servers/pylsp-all/venv"
+SITE_PACKAGES=""
+PYTHON_VERSION=""
+
+for dir in "${VENV}"/lib/python3.*; do
+  if [ -d "${dir}/site-packages" ]; then
+    SITE_PACKAGES="${dir}/site-packages"
+    PYTHON_VERSION=$(basename "${dir}")
+    PYTHON_VERSION=${PYTHON_VERSION#python}
+    break
+  fi
+done
+
+if [ -z "${SITE_PACKAGES}" ] || [ -z "${PYTHON_VERSION}" ]; then
+  echo "pylsp-all wrapper could not find site-packages under ${VENV}" >&2
+  exit 1
+fi
+
+if command -v "python${PYTHON_VERSION}" >/dev/null 2>&1; then
+  PYTHON_BIN="python${PYTHON_VERSION}"
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+else
+  echo "pylsp-all wrapper could not find a Python interpreter" >&2
+  exit 1
+fi
+
+if ! "${PYTHON_BIN}" -c "import sys; raise SystemExit(0 if sys.version_info[:2] == tuple(map(int, '${PYTHON_VERSION}'.split('.'))) else 1)" >/dev/null 2>&1; then
+  echo "pylsp-all wrapper requires Python ${PYTHON_VERSION}" >&2
+  exit 1
+fi
+
+PATH="${VENV}/bin:${PATH}" \
+PYTHONPATH="${SITE_PACKAGES}${PYTHONPATH:+:${PYTHONPATH}}" \
+exec "${PYTHON_BIN}" -m pylsp "$@"

--- a/vimrc
+++ b/vimrc
@@ -43,6 +43,27 @@ filetype plugin indent off                   " (1)
 
 let s:dein_path = expand('~/.vim/dein')
 let s:dein_repo_dir = s:dein_path . '/repos/github.com/Shougo/dein.vim'
+let s:default_vimrc = expand('~/.vimrc')
+let s:default_vimrc_resolved = resolve(s:default_vimrc)
+
+" Keep dein's cache key stable even when ~/.vimrc is a symlink to this repo.
+if $MYVIMRC ==# '' || resolve(expand($MYVIMRC)) ==# s:default_vimrc_resolved
+  let $MYVIMRC = s:default_vimrc
+endif
+
+let s:dein_state = s:dein_path . '/state_' . fnamemodify(v:progname, ':r') . '.vim'
+let s:dein_cache = s:dein_path . '/cache_' . fnamemodify(v:progname, ':r')
+let s:stale_runtime = s:dein_path . '/.cache/vimrc/.dein'
+
+" If a state file points at an empty merged runtime cache, force a rebuild.
+if filereadable(s:dein_state)
+  let s:state_runtime_line = 'let g:dein#_runtime_path = ' . string(s:stale_runtime)
+  if index(readfile(s:dein_state), s:state_runtime_line) >= 0
+        \ && !filereadable(s:stale_runtime . '/autoload/ddc.vim')
+    call delete(s:dein_state)
+    call delete(s:dein_cache)
+  endif
+endif
 
 if &runtimepath !~# '/dein.vim'
   if !isdirectory(s:dein_repo_dir)
@@ -68,6 +89,7 @@ if dein#load_state(s:dein_path)
   
   call dein#end()
   call dein#save_state()
+  call dein#recache_runtimepath()
 endif
 
 filetype plugin indent on
@@ -124,6 +146,7 @@ nnoremap K :<C-u>LspHover<CR>
 
 let g:lsp_settings = {
 \   'pylsp-all': {
+\     'cmd': [expand('~/.vim/bin/pylsp-all')],
 \     'workspace_config': {
 \       'pylsp': {
 \         'configurationSources': ['flake8'],


### PR DESCRIPTION
## Summary
- recover from broken dein startup cache by rebuilding runtimepath state when needed
- route pylsp-all through a wrapper so Vim LSP does not depend on a stale virtualenv interpreter symlink
- add a Vim startup regression test that checks plugin cache generation and startup errors

## Testing
- /bin/zsh test/run.zsh