### PR TITLE
Guard Vim ddc setup on unsupported versions

### DIFF
--- a/test/test-vim-startup.zsh
+++ b/test/test-vim-startup.zsh
@@ -38,6 +38,7 @@ ln -s "$PYLSP_ALL_SOURCE" "$tmp_home/.local/share/vim-lsp-settings/servers/pylsp
 
 typeset -r log_path="$tmp_home/vim.log"
 typeset -r messages_path="$tmp_home/messages.txt"
+typeset -r ddc_support_path="$tmp_home/ddc-support.txt"
 
 typeset -a vim_args=(
   -Nu NONE
@@ -49,6 +50,7 @@ typeset -a vim_args=(
   --cmd 'set nomore'
   "+source $tmp_home/.vimrc"
   '+call dein#source()'
+  "+call writefile([string(has('nvim-0.11.3') || has('patch-9.1.1646'))], '$ddc_support_path')"
   "+redir => g:msgs | silent messages | redir END | call writefile(split(g:msgs, \"\\n\"), '$messages_path')"
   '+qall!'
 )
@@ -64,7 +66,12 @@ fi
 HOME="$tmp_home" "$REPO_ROOT/vim/bin/pylsp-all" --version >/dev/null 2>&1 \
   || fail "pylsp-all wrapper did not start from the temp HOME"
 
-assert_exists "$tmp_home/.vim/dein/.cache/.vimrc/.dein/autoload/ddc.vim"
+ddc_supported="$(<"$ddc_support_path")"
+if [[ "$ddc_supported" == "1" ]]; then
+  assert_exists "$tmp_home/.vim/dein/.cache/.vimrc/.dein/autoload/ddc.vim"
+else
+  assert_not_exists "$tmp_home/.vim/dein/.cache/.vimrc/.dein/autoload/ddc.vim"
+fi
 assert_exists "$tmp_home/.vim/dein/.cache/.vimrc/.dein/autoload/lsp.vim"
 assert_exists "$tmp_home/.vim/dein/.cache/.vimrc/.dein/colors/molokai.vim"
 

--- a/vim/dein/userconfig/plugins.toml
+++ b/vim/dein/userconfig/plugins.toml
@@ -28,35 +28,45 @@
 [[plugins]]
   repo = 'vim-scripts/EnhCommentify.vim'
 
+# Neovim 0.9.x is below the minimum supported version for current denops/ddc.
 [[plugins]]
   repo = 'Shougo/ddc.vim'
+  if = "has('nvim-0.11.3') || has('patch-9.1.1646')"
 
 [[plugins]]
   repo = 'vim-denops/denops.vim'
+  if = "has('nvim-0.11.3') || has('patch-9.1.1646')"
 
 [[plugins]]
   repo = 'Shougo/pum.vim'
 
 [[plugins]]
   repo = 'Shougo/ddc-around'
+  if = "has('nvim-0.11.3') || has('patch-9.1.1646')"
 
 [[plugins]]
   repo = 'LumaKernel/ddc-file'
+  if = "has('nvim-0.11.3') || has('patch-9.1.1646')"
 
 [[plugins]]
   repo = 'shun/ddc-vim-lsp'
+  if = "has('nvim-0.11.3') || has('patch-9.1.1646')"
 
 [[plugins]]
   repo = 'Shougo/ddc-matcher_head'
+  if = "has('nvim-0.11.3') || has('patch-9.1.1646')"
 
 [[plugins]]
   repo = 'Shougo/ddc-ui-native'
+  if = "has('nvim-0.11.3') || has('patch-9.1.1646')"
 
 [[plugins]]
   repo = 'Shougo/ddc-sorter_rank'
+  if = "has('nvim-0.11.3') || has('patch-9.1.1646')"
 
 [[plugins]]
   repo = 'Shougo/ddc-converter_remove_overlap'
+  if = "has('nvim-0.11.3') || has('patch-9.1.1646')"
 
 [[plugins]]
   repo = 'rhysd/vim-healthcheck'

--- a/vimrc
+++ b/vimrc
@@ -89,7 +89,12 @@ if dein#load_state(s:dein_path)
   
   call dein#end()
   call dein#save_state()
-  call dein#recache_runtimepath()
+
+  " Rebuild dein's generated runtime tree if the cache directory is empty.
+  if !exists('g:dein#_runtime_path')
+        \ || empty(globpath(g:dein#_runtime_path, '*', 0, 1))
+    call dein#recache_runtimepath()
+  endif
 endif
 
 filetype plugin indent on
@@ -105,7 +110,7 @@ filetype plugin indent on     " (5)
 """""""""""""""""
 " colorscheme
 """""""""""""""""
-colorscheme molokai
+silent! colorscheme molokai
 
 """""""""""""""""""""
 " ctrlp
@@ -184,32 +189,34 @@ let g:lsp_settings = {
 """""
 " ddc
 """""
-call ddc#custom#patch_global('ui', 'pum.vim')
-call ddc#custom#patch_global('ui', 'native')
-call ddc#custom#patch_global('sources', [
- \ 'around',
- \ 'vim-lsp',
- \ 'file',
- \ 'neosnippet'
- \ ])
-call ddc#custom#patch_global('sourceOptions', {
- \ '_': {
- \   'matchers': ['matcher_head'],
- \   'sorters': ['sorter_rank'],
- \   'converters': ['converter_remove_overlap'],
- \ },
- \ 'around': {'mark': 'Around'},
- \ 'neosnippet': {'mark': 'Snippet'},
- \ 'vim-lsp': {
- \   'mark': 'LSP', 
- \   'matchers': ['matcher_head'],
- \   'forceCompletionPattern': '\.|:|->|"\w+/*'
- \ },
- \ 'file': {
- \   'mark': 'file',
- \   'isVolatile': v:true, 
- \   'forceCompletionPattern': '\S/\S*'
- \ }})
+if exists('*ddc#custom#patch_global')
+  call ddc#custom#patch_global('ui', 'pum.vim')
+  call ddc#custom#patch_global('ui', 'native')
+  call ddc#custom#patch_global('sources', [
+   \ 'around',
+   \ 'vim-lsp',
+   \ 'file',
+   \ 'neosnippet'
+   \ ])
+  call ddc#custom#patch_global('sourceOptions', {
+   \ '_': {
+   \   'matchers': ['matcher_head'],
+   \   'sorters': ['sorter_rank'],
+   \   'converters': ['converter_remove_overlap'],
+   \ },
+   \ 'around': {'mark': 'Around'},
+   \ 'neosnippet': {'mark': 'Snippet'},
+   \ 'vim-lsp': {
+   \   'mark': 'LSP',
+   \   'matchers': ['matcher_head'],
+   \   'forceCompletionPattern': '\.|:|->|"\w+/*'
+   \ },
+   \ 'file': {
+   \   'mark': 'file',
+   \   'isVolatile': v:true,
+   \   'forceCompletionPattern': '\S/\S*'
+   \ }})
+endif
 
 
 let g:lightline = {
@@ -233,9 +240,13 @@ let g:lightline = {
 let g:lsp_diagnostics_signs_enabled = 0
 highlight link LspWarningHighlight Error
 
-call ddc#enable()
-inoremap <Tab> <Cmd>call pum#map#insert_relative(+1)<CR>
-inoremap <S-Tab> <Cmd>call pum#map#insert_relative(-1)<CR>
+if exists('*ddc#enable')
+  call ddc#enable()
+endif
+if exists('*pum#map#insert_relative')
+  inoremap <Tab> <Cmd>call pum#map#insert_relative(+1)<CR>
+  inoremap <S-Tab> <Cmd>call pum#map#insert_relative(-1)<CR>
+endif
 
 
 """""""""""""""""""""
@@ -299,10 +310,15 @@ let g:rbpt_colorpairs = [
 
 let g:rbpt_max = 16
 let g:rbpt_loadcmd_toggle = 0
-au VimEnter * RainbowParenthesesToggle
-au Syntax * RainbowParenthesesLoadRound
-au Syntax * RainbowParenthesesLoadSquare
-au Syntax * RainbowParenthesesLoadBraces
+augroup RainbowParentheses
+  autocmd!
+  autocmd VimEnter * if exists(':RainbowParenthesesToggle') | silent! RainbowParenthesesToggle | endif
+  autocmd Syntax * if exists(':RainbowParenthesesLoadRound') |
+        \ silent! RainbowParenthesesLoadRound |
+        \ silent! RainbowParenthesesLoadSquare |
+        \ silent! RainbowParenthesesLoadBraces |
+        \ endif
+augroup END
 
 
 augroup LspAutoFormatting


### PR DESCRIPTION
## Summary

  - Skip denops/ddc plugins on unsupported Vim/Neovim versions
  - Guard Vim startup hooks when optional plugins are unavailable
  - Update Vim startup test expectations for conditional ddc loading

  ## Background

  Current denops/ddc requires newer Vim/Neovim versions than some environments provide. Without guards, Vim startup can fail when ddc-related functions or optional plugin commands are unavailable.

  This keeps Vim startup usable on older versions while preserving ddc setup on supported versions.

  ## Tests

  - `zsh test/run.zsh`
  - `zsh -n zshrc zpreztorc zshrc.local`
  - `git diff --check`