### PR TITLE
Add Neovim entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ zshrc.local
 vim/dein/repos
 vim/dein/.cache
 vim/dein/cache_vim
+vim/dein/cache_nvim
 vim/dein/state_vim.vim
+vim/dein/state_nvim.vim
 vim/black

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Managed configs:
 
 - `zsh`
 - `vim`
+- `Neovim`
 - `tmux`
 - `ssh`
 - `Ghostty`
@@ -70,6 +71,11 @@ When that overlay repository exists, `init.zsh` links:
 - Plugin lists live in `vim/dein/userconfig/plugins.toml` and
   `vim/dein/userconfig/plugins_lazy.toml`
 - Deno-backed completion plugins are supported, so `init.zsh` installs Deno
+
+### Neovim
+
+- `nvim/init.vim` reuses the shared Vim configuration from `~/.vimrc`
+- `init.zsh` links it to `~/.config/nvim/init.vim`
 
 ### SSH
 

--- a/init.zsh
+++ b/init.zsh
@@ -123,6 +123,8 @@ install_dotfiles() {
     link_files "$DOTFILES_DIR/tmux.conf" ~/.tmux.conf
     link_files "$DOTFILES_DIR/vimrc" ~/.vimrc
     link_files "$DOTFILES_DIR/vim" ~/.vim
+    mkdir -p ~/.config/nvim
+    link_files "$DOTFILES_DIR/nvim/init.vim" ~/.config/nvim/init.vim
     link_files "$DOTFILES_DIR/zshrc" ~/.zshrc
     link_files "$DOTFILES_DIR/zpreztorc" ~/.zpreztorc
     mkdir -p ~/.local/bin

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -1,0 +1,7 @@
+" Reuse the shared Vim configuration from Neovim without maintaining a
+" separate plugin stack.
+set runtimepath^=~/.vim
+set runtimepath+=~/.vim/after
+let &packpath = &runtimepath
+let $MYVIMRC = expand('~/.vimrc')
+source ~/.vimrc

--- a/test/test-init.zsh
+++ b/test/test-init.zsh
@@ -10,12 +10,13 @@ source "${0:A:h}/lib.zsh"
 tmp_home="$(make_temp_dir dotfiles-init-home)"
 private_dir="$(make_temp_dir dotfiles-private)"
 
-mkdir -p "$tmp_home/.deno/bin" "$tmp_home/.ssh" "$tmp_home/.config/ghostty" "$private_dir/ssh"
+mkdir -p "$tmp_home/.deno/bin" "$tmp_home/.ssh" "$tmp_home/.config/ghostty" "$tmp_home/.config/nvim" "$private_dir/ssh"
 print -r -- '#!/bin/sh' > "$tmp_home/.deno/bin/deno"
 print -r -- 'exit 0' >> "$tmp_home/.deno/bin/deno"
 chmod +x "$tmp_home/.deno/bin/deno"
 
 print -r -- 'legacy zshrc' > "$tmp_home/.zshrc"
+print -r -- 'legacy nvim init' > "$tmp_home/.config/nvim/init.vim"
 print -r -- 'legacy ssh config' > "$tmp_home/.ssh/config"
 print -r -- 'export DOTFILES_PRIVATE_TEST=1' > "$private_dir/zshrc.local"
 print -r -- 'Host private-host' > "$private_dir/ssh/config.local"
@@ -41,6 +42,7 @@ assert_symlink_target "$tmp_home/.pyenv" "$REPO_ROOT/pyenv"
 assert_symlink_target "$tmp_home/.zshrc" "$REPO_ROOT/zshrc"
 assert_symlink_target "$tmp_home/.zpreztorc" "$REPO_ROOT/zpreztorc"
 assert_symlink_target "$tmp_home/.vimrc" "$REPO_ROOT/vimrc"
+assert_symlink_target "$tmp_home/.config/nvim/init.vim" "$REPO_ROOT/nvim/init.vim"
 assert_symlink_target "$tmp_home/.tmux.conf" "$REPO_ROOT/tmux.conf"
 assert_symlink_target "$tmp_home/.local/bin/md-preview-server" "$REPO_ROOT/bin/md-preview-server"
 assert_symlink_target "$tmp_home/.codex/skills/cmux-markdown-preview" "$REPO_ROOT/.agents/skills/cmux-markdown-preview"
@@ -51,10 +53,13 @@ assert_symlink_target "$tmp_home/.zshrc.local" "$private_dir/zshrc.local"
 assert_symlink_target "$tmp_home/.ssh/config.local" "$private_dir/ssh/config.local"
 
 zshrc_backups=("$tmp_home"/.zshrc.backup.*(N))
+nvim_init_backups=("$tmp_home"/.config/nvim/init.vim.backup.*(N))
 ssh_config_backups=("$tmp_home"/.ssh/config.backup.*(N))
 assert_eq "${#zshrc_backups[@]}" "1" "expected one .zshrc backup after the first install"
+assert_eq "${#nvim_init_backups[@]}" "1" "expected one Neovim init backup after the first install"
 assert_eq "${#ssh_config_backups[@]}" "1" "expected one SSH config backup after the first install"
 assert_contains "$(cat "$zshrc_backups[1]")" "legacy zshrc"
+assert_contains "$(cat "$nvim_init_backups[1]")" "legacy nvim init"
 assert_contains "$(cat "$ssh_config_backups[1]")" "legacy ssh config"
 
 if [[ "$(uname)" == "Darwin" ]]; then
@@ -78,8 +83,10 @@ fi
 )
 
 zshrc_backups=("$tmp_home"/.zshrc.backup.*(N))
+nvim_init_backups=("$tmp_home"/.config/nvim/init.vim.backup.*(N))
 ssh_config_backups=("$tmp_home"/.ssh/config.backup.*(N))
 assert_eq "${#zshrc_backups[@]}" "1" "expected .zshrc backups to stay stable across repeated installs"
+assert_eq "${#nvim_init_backups[@]}" "1" "expected Neovim init backups to stay stable across repeated installs"
 assert_eq "${#ssh_config_backups[@]}" "1" "expected SSH config backups to stay stable across repeated installs"
 
 if [[ "$(uname)" == "Darwin" ]]; then

--- a/test/test-nvim-startup.zsh
+++ b/test/test-nvim-startup.zsh
@@ -1,0 +1,87 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+source "${0:A:h}/lib.zsh"
+
+skip() {
+  print -r -- "SKIP: $1"
+  exit 0
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local message="${3:-unexpected output contains '$needle'}"
+
+  [[ "$haystack" != *"$needle"* ]] || fail "$message"
+}
+
+typeset nvim_bin="${DOTFILES_TEST_NVIM:-}"
+if [[ -z "$nvim_bin" ]]; then
+  if command -v nvim >/dev/null 2>&1; then
+    nvim_bin="$(command -v nvim)"
+  elif [[ -x /opt/homebrew/bin/nvim ]]; then
+    nvim_bin=/opt/homebrew/bin/nvim
+  else
+    skip "nvim is not installed"
+  fi
+fi
+
+typeset -r DEIN_REPOS_SOURCE="${DOTFILES_TEST_DEIN_REPOS:-$HOME/.vim/dein/repos}"
+
+[[ -x "$nvim_bin" ]] || skip "nvim is not executable at $nvim_bin"
+[[ -d "$DEIN_REPOS_SOURCE/github.com/Shougo/dein.vim" ]] || skip "dein repos are not available at $DEIN_REPOS_SOURCE"
+[[ -d "$DEIN_REPOS_SOURCE/github.com/Shougo/ddc.vim" ]] || skip "ddc.vim is not available at $DEIN_REPOS_SOURCE"
+
+tmp_home="$(make_temp_dir dotfiles-nvim-home)"
+mkdir -p \
+  "$tmp_home/.config/nvim" \
+  "$tmp_home/.vim/dein" \
+  "$tmp_home/.local/state" \
+  "$tmp_home/.local/share" \
+  "$tmp_home/.cache"
+
+ln -s "$REPO_ROOT/nvim/init.vim" "$tmp_home/.config/nvim/init.vim"
+ln -s "$REPO_ROOT/vimrc" "$tmp_home/.vimrc"
+ln -s "$REPO_ROOT/vim/bin" "$tmp_home/.vim/bin"
+ln -s "$REPO_ROOT/vim/snippet" "$tmp_home/.vim/snippet"
+ln -s "$REPO_ROOT/vim/dein/userconfig" "$tmp_home/.vim/dein/userconfig"
+ln -s "$DEIN_REPOS_SOURCE" "$tmp_home/.vim/dein/repos"
+
+typeset -r log_path="$tmp_home/nvim.log"
+typeset -r check_path="$tmp_home/check.txt"
+typeset -r messages_path="$tmp_home/messages.txt"
+
+typeset -a nvim_args=(
+  --headless
+  -n
+  -i NONE
+  --cmd 'set nomore'
+  "+redir => g:check | silent echo has('nvim-0.11.3') | silent echo executable('deno') | silent echo exists('*ddc#enable') | redir END | call writefile(split(g:check, \"\\n\"), '$check_path')"
+  "+redir => g:msgs | silent messages | redir END | call writefile(split(g:msgs, \"\\n\"), '$messages_path')"
+  '+qall!'
+)
+
+if ! HOME="$tmp_home" \
+    XDG_CONFIG_HOME="$tmp_home/.config" \
+    XDG_DATA_HOME="$tmp_home/.local/share" \
+    XDG_STATE_HOME="$tmp_home/.local/state" \
+    XDG_CACHE_HOME="$tmp_home/.cache" \
+    "$nvim_bin" "${nvim_args[@]}" >"$log_path" 2>&1; then
+  print -u2 -- "nvim startup test failed:"
+  sed -n '1,200p' "$log_path" >&2 || true
+  [[ -f "$messages_path" ]] && sed -n '1,200p' "$messages_path" >&2 || true
+  fail "nvim exited with a non-zero status"
+fi
+
+typeset -a checks=("${(@f)$(<"$check_path")}")
+
+[[ "${checks[1]:-0}" == "1" ]] || skip "nvim is below the ddc-supported version"
+[[ "${checks[2]:-0}" == "1" ]] || skip "deno is not executable from nvim"
+assert_eq "${checks[3]:-0}" "1" "expected ddc#enable to be loaded in Neovim"
+
+messages_content=""
+[[ -f "$messages_path" ]] && messages_content="$(<"$messages_path")"
+assert_not_contains "$messages_content" 'E519:' "Neovim-only unsupported options are still set"
+assert_not_contains "$messages_content" 'poet-v' "poet-v is still loaded for Neovim startup"

--- a/vim/dein/userconfig/plugins_lazy.toml
+++ b/vim/dein/userconfig/plugins_lazy.toml
@@ -1,8 +1,4 @@
 [[plugins]]
-  repo = 'petobens/poet-v'
-  on_ft = ['python']
-
-[[plugins]]
   repo = 'python-lsp/python-lsp-black'
   on_ft = ['python']
 

--- a/vimrc
+++ b/vimrc
@@ -4,7 +4,9 @@ set encoding=utf-8
 set fileencodings=utf-8
 
 " 256 colors
-set t_Co=256 
+if exists('&t_Co')
+  set t_Co=256
+endif
 
 set nu
 set completeopt=menuone
@@ -13,7 +15,9 @@ filetype on
 set hlsearch
 set showmatch
 set laststatus=2
-set guioptions+=a
+if !has('nvim') && exists('&guioptions')
+  set guioptions+=a
+endif
 
 set wildmenu
 
@@ -189,7 +193,12 @@ let g:lsp_settings = {
 """""
 " ddc
 """""
-if exists('*ddc#custom#patch_global')
+let s:ddc_supported = (has('nvim-0.11.3') || has('patch-9.1.1646')) && executable('deno')
+let s:ddc_available = s:ddc_supported
+      \ && !empty(globpath(&runtimepath, 'autoload/ddc.vim'))
+      \ && !empty(globpath(&runtimepath, 'autoload/ddc/custom.vim'))
+
+if s:ddc_available
   call ddc#custom#patch_global('ui', 'pum.vim')
   call ddc#custom#patch_global('ui', 'native')
   call ddc#custom#patch_global('sources', [
@@ -240,10 +249,10 @@ let g:lightline = {
 let g:lsp_diagnostics_signs_enabled = 0
 highlight link LspWarningHighlight Error
 
-if exists('*ddc#enable')
+if s:ddc_available
   call ddc#enable()
 endif
-if exists('*pum#map#insert_relative')
+if s:ddc_supported && !empty(globpath(&runtimepath, 'autoload/pum/map.vim'))
   inoremap <Tab> <Cmd>call pum#map#insert_relative(+1)<CR>
   inoremap <S-Tab> <Cmd>call pum#map#insert_relative(-1)<CR>
 endif


### PR DESCRIPTION
## Summary
- add a managed Neovim `init.vim` that reuses the shared Vim configuration
- link `~/.config/nvim/init.vim` from `init.zsh` and document Neovim support
- make Vim options/ddc startup safe under Neovim and remove unused `poet-v`
- ignore Neovim dein state/cache files and add a Neovim startup smoke test

## Validation
- `zsh test/test-nvim-startup.zsh`
- `zsh test/test-vim-startup.zsh`
- `zsh test/test-init.zsh`
- `zsh test/run.zsh`
- `git diff --check`