### PR TITLE
Install Neovim from official tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*.swp
+nvim.log
 ssh/config.local
 zshrc.local
 vim/dein/repos

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Managed configs:
 - `git`
 - `curl`
 - `zsh`
+- `tar` on Linux when Neovim needs to be installed
 
 ### Install
 
@@ -35,8 +36,12 @@ zsh init.zsh
 ```
 
 `init.zsh` initializes submodules, backs up existing files when needed, creates
-symlinks, and installs Deno if `$HOME/.deno/bin/deno` does not exist. Existing
-files are backed up as `*.backup.<timestamp>`.
+symlinks, installs Neovim on supported Linux systems when it is missing or too
+old, and installs Deno if `$HOME/.deno/bin/deno` does not exist. Existing files
+are backed up as `*.backup.<timestamp>`.
+
+Set `DOTFILES_SKIP_NVIM_INSTALL=1` before running `init.zsh` to manage Neovim
+outside this bootstrap.
 
 ## Local Overrides
 
@@ -61,7 +66,8 @@ When that overlay repository exists, `init.zsh` links:
 
 - `zprezto` is included as a git submodule
 - Main shell settings live in `zpreztorc`
-- `zshrc` sets up `pyenv`, Deno, Prezto, and local overrides
+- `zshrc` puts `~/.local/bin` on `PATH` and sets up `pyenv`, Deno,
+  Prezto, and local overrides
 - `zshrc` loads `~/.zshrc.local` first, then a repo-local `zshrc.local` if present
 - For cmux relay behavior and SSH alias setup, see `docs/cmux.md`
 
@@ -76,6 +82,9 @@ When that overlay repository exists, `init.zsh` links:
 
 - `nvim/init.vim` reuses the shared Vim configuration from `~/.vimrc`
 - `init.zsh` links it to `~/.config/nvim/init.vim`
+- On Linux x86_64/arm64, `init.zsh` installs the official Neovim tarball to
+  `~/.local/opt/dotfiles/` and links `~/.local/bin/nvim` when no Neovim at
+  least `0.11.3` is available
 
 ### SSH
 

--- a/init.zsh
+++ b/init.zsh
@@ -1,6 +1,7 @@
 #!/bin/zsh
 
 typeset -gr DOTFILES_DIR="${${(%):-%N}:A:h}"
+typeset -gr DOTFILES_NVIM_MIN_VERSION="${DOTFILES_NVIM_MIN_VERSION:-0.11.3}"
 
 success() {
     printf "\r\033[2K  [ \033[00;32mOK\033[0m ] $1\n"
@@ -108,6 +109,186 @@ install_deno() {
 }
 
 
+nvim_version() {
+    local nvim_bin="$1"
+    local first_line
+    local version
+
+    first_line="$("$nvim_bin" --version 2>/dev/null || true)"
+    first_line="${first_line%%$'\n'*}"
+
+    if [[ "$first_line" == NVIM\ v* ]]; then
+        version="${first_line#NVIM v}"
+    elif [[ "$first_line" == NVIM\ * ]]; then
+        version="${first_line#NVIM }"
+    else
+        return 1
+    fi
+
+    print -r -- "${version%% *}"
+}
+
+
+version_at_least() {
+    local version="${1#v}"
+    local minimum="${2#v}"
+    local version_core="${version%%[-+]*}"
+    local minimum_core="${minimum%%[-+]*}"
+    local -a version_parts minimum_parts
+    local i version_part minimum_part
+
+    version_parts=(${(s:.:)version_core})
+    minimum_parts=(${(s:.:)minimum_core})
+
+    for i in 1 2 3; do
+        version_part="${version_parts[$i]:-0}"
+        minimum_part="${minimum_parts[$i]:-0}"
+        version_part="${version_part//[^0-9]/}"
+        minimum_part="${minimum_part//[^0-9]/}"
+        [[ -n "$version_part" ]] || version_part=0
+        [[ -n "$minimum_part" ]] || minimum_part=0
+
+        if (( version_part > minimum_part )); then
+            return 0
+        elif (( version_part < minimum_part )); then
+            return 1
+        fi
+    done
+
+    return 0
+}
+
+
+nvim_candidates() {
+    local command_nvim
+
+    if [[ -x "$HOME/.local/bin/nvim" ]]; then
+        print -r -- "$HOME/.local/bin/nvim"
+    fi
+
+    if command -v nvim >/dev/null 2>&1; then
+        command_nvim="$(command -v nvim)"
+        if [[ "$command_nvim" != "$HOME/.local/bin/nvim" ]]; then
+            print -r -- "$command_nvim"
+        fi
+    fi
+}
+
+
+nvim_meets_minimum() {
+    local nvim_bin
+    local version
+    local old_version=""
+    local old_bin=""
+
+    for nvim_bin in ${(f)"$(nvim_candidates)"}; do
+        version="$(nvim_version "$nvim_bin")" || continue
+        if version_at_least "$version" "$DOTFILES_NVIM_MIN_VERSION"; then
+            success "Neovim $version is available at $nvim_bin"
+            return 0
+        fi
+
+        if [[ -z "$old_version" ]]; then
+            old_version="$version"
+            old_bin="$nvim_bin"
+        fi
+    done
+
+    if [[ -n "$old_version" ]]; then
+        warn "Neovim $old_version at $old_bin is older than $DOTFILES_NVIM_MIN_VERSION"
+    else
+        warn "Neovim is not installed"
+    fi
+
+    return 1
+}
+
+
+nvim_asset_name() {
+    local os_name="$1"
+    local arch_name="$2"
+
+    [[ "$os_name" == "Linux" ]] || return 1
+
+    case "$arch_name" in
+        x86_64|amd64)
+            print -r -- "nvim-linux-x86_64"
+            ;;
+        aarch64|arm64)
+            print -r -- "nvim-linux-arm64"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+
+install_neovim() {
+    if [[ -n "${DOTFILES_SKIP_NVIM_INSTALL:-}" ]]; then
+        info "Skipping Neovim install because DOTFILES_SKIP_NVIM_INSTALL is set"
+        return 0
+    fi
+
+    if nvim_meets_minimum; then
+        return 0
+    fi
+
+    local os_name
+    local arch_name
+    local asset_name
+    local archive_url
+    local install_parent="${DOTFILES_NVIM_INSTALL_PARENT:-$HOME/.local/opt/dotfiles}"
+    local bin_dir="${DOTFILES_NVIM_BIN_DIR:-$HOME/.local/bin}"
+    local install_dir
+    local archive_path
+    local extract_dir
+    local extracted_dir
+
+    os_name="$(uname)"
+    arch_name="$(uname -m)"
+    if ! asset_name="$(nvim_asset_name "$os_name" "$arch_name")"; then
+        warn "Automatic Neovim install is only supported on Linux x86_64/arm64"
+        warn "Detected $os_name/$arch_name. Skipping Neovim install."
+        return 0
+    fi
+
+    if ! command -v tar >/dev/null 2>&1; then
+        error "tar is required to install Neovim"
+        exit 1
+    fi
+
+    info "Installing Neovim $DOTFILES_NVIM_MIN_VERSION+ from official tarball..."
+
+    archive_url="https://github.com/neovim/neovim/releases/latest/download/$asset_name.tar.gz"
+    install_dir="$install_parent/$asset_name"
+    archive_path="$(mktemp "${TMPDIR:-/tmp}/$asset_name.XXXXXX")"
+    extract_dir="$(mktemp -d "${TMPDIR:-/tmp}/$asset_name.XXXXXX")"
+
+    if curl -fsSL "$archive_url" -o "$archive_path"; then
+        mkdir -p "$install_parent" "$bin_dir"
+        tar -C "$extract_dir" -xzf "$archive_path"
+        extracted_dir="$extract_dir/$asset_name"
+
+        if [[ ! -x "$extracted_dir/bin/nvim" ]]; then
+            error "Downloaded Neovim archive did not contain $asset_name/bin/nvim"
+            rm -rf -- "$archive_path" "$extract_dir"
+            exit 1
+        fi
+
+        rm -rf -- "$install_dir"
+        mv -- "$extracted_dir" "$install_dir"
+        ln -sfn "$install_dir/bin/nvim" "$bin_dir/nvim"
+        rm -rf -- "$archive_path" "$extract_dir"
+        success "installed Neovim to $install_dir"
+    else
+        rm -rf -- "$archive_path" "$extract_dir"
+        error "Failed to download Neovim from $archive_url"
+        exit 1
+    fi
+}
+
+
 install_dotfiles() {
     info "Installing dotfiles..."
     local private_dotfiles_dir="${DOTFILES_PRIVATE_DIR:-$HOME/work/dotfiles-private}"
@@ -175,6 +356,7 @@ main() {
     check_os_compatibility
     setup_git_submodule
     install_dotfiles
+    install_neovim
 
     if [ ! -e "$HOME/.deno/bin/deno" ]; then
         install_deno

--- a/test/test-init.zsh
+++ b/test/test-init.zsh
@@ -10,10 +10,19 @@ source "${0:A:h}/lib.zsh"
 tmp_home="$(make_temp_dir dotfiles-init-home)"
 private_dir="$(make_temp_dir dotfiles-private)"
 
-mkdir -p "$tmp_home/.deno/bin" "$tmp_home/.ssh" "$tmp_home/.config/ghostty" "$tmp_home/.config/nvim" "$private_dir/ssh"
+mkdir -p \
+  "$tmp_home/.deno/bin" \
+  "$tmp_home/.local/bin" \
+  "$tmp_home/.ssh" \
+  "$tmp_home/.config/ghostty" \
+  "$tmp_home/.config/nvim" \
+  "$private_dir/ssh"
 print -r -- '#!/bin/sh' > "$tmp_home/.deno/bin/deno"
 print -r -- 'exit 0' >> "$tmp_home/.deno/bin/deno"
 chmod +x "$tmp_home/.deno/bin/deno"
+print -r -- '#!/bin/sh' > "$tmp_home/.local/bin/nvim"
+print -r -- 'printf "%s\n" "NVIM v0.11.3"' >> "$tmp_home/.local/bin/nvim"
+chmod +x "$tmp_home/.local/bin/nvim"
 
 print -r -- 'legacy zshrc' > "$tmp_home/.zshrc"
 print -r -- 'legacy nvim init' > "$tmp_home/.config/nvim/init.vim"

--- a/test/test-neovim-install.zsh
+++ b/test/test-neovim-install.zsh
@@ -1,0 +1,66 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+source "${0:A:h}/lib.zsh"
+
+export DOTFILES_SOURCE_ONLY=1
+source "$REPO_ROOT/init.zsh"
+
+version_at_least "0.11.3" "0.11.3" || fail "expected equal Neovim versions to be accepted"
+version_at_least "0.12.0" "0.11.3" || fail "expected newer Neovim version to be accepted"
+if version_at_least "0.11.2" "0.11.3"; then
+  fail "expected older Neovim version to be rejected"
+fi
+
+skip_home="$(make_temp_dir dotfiles-nvim-skip-home)"
+(
+  HOME="$skip_home"
+  export HOME DOTFILES_SKIP_NVIM_INSTALL=1
+  install_neovim
+)
+assert_not_exists "$skip_home/.local/bin/nvim"
+
+install_home="$(make_temp_dir dotfiles-nvim-install-home)"
+archive_root="$(make_temp_dir dotfiles-nvim-archive-root)"
+fake_bin="$(make_temp_dir dotfiles-nvim-fake-bin)"
+archive_path="$archive_root/nvim-linux-x86_64.tar.gz"
+
+mkdir -p "$archive_root/nvim-linux-x86_64/bin"
+print -r -- '#!/bin/sh' > "$archive_root/nvim-linux-x86_64/bin/nvim"
+print -r -- 'printf "%s\n" "NVIM v0.12.0"' >> "$archive_root/nvim-linux-x86_64/bin/nvim"
+chmod +x "$archive_root/nvim-linux-x86_64/bin/nvim"
+tar -C "$archive_root" -czf "$archive_path" nvim-linux-x86_64
+
+print -r -- '#!/bin/sh' > "$fake_bin/uname"
+print -r -- 'if [ "$1" = "-m" ]; then' >> "$fake_bin/uname"
+print -r -- '  printf "%s\n" "x86_64"' >> "$fake_bin/uname"
+print -r -- 'else' >> "$fake_bin/uname"
+print -r -- '  printf "%s\n" "Linux"' >> "$fake_bin/uname"
+print -r -- 'fi' >> "$fake_bin/uname"
+chmod +x "$fake_bin/uname"
+
+print -r -- '#!/bin/sh' > "$fake_bin/curl"
+print -r -- 'out=""' >> "$fake_bin/curl"
+print -r -- 'while [ "$#" -gt 0 ]; do' >> "$fake_bin/curl"
+print -r -- '  if [ "$1" = "-o" ]; then' >> "$fake_bin/curl"
+print -r -- '    shift' >> "$fake_bin/curl"
+print -r -- '    out="$1"' >> "$fake_bin/curl"
+print -r -- '  fi' >> "$fake_bin/curl"
+print -r -- '  shift' >> "$fake_bin/curl"
+print -r -- 'done' >> "$fake_bin/curl"
+print -r -- '[ -n "$out" ] || exit 2' >> "$fake_bin/curl"
+print -r -- 'cp "$DOTFILES_TEST_NVIM_ARCHIVE" "$out"' >> "$fake_bin/curl"
+chmod +x "$fake_bin/curl"
+
+(
+  HOME="$install_home"
+  PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  DOTFILES_TEST_NVIM_ARCHIVE="$archive_path"
+  export HOME PATH DOTFILES_TEST_NVIM_ARCHIVE
+  install_neovim
+)
+
+expected_nvim="$install_home/.local/opt/dotfiles/nvim-linux-x86_64/bin/nvim"
+assert_symlink_target "$install_home/.local/bin/nvim" "$expected_nvim"
+assert_contains "$("$install_home/.local/bin/nvim" --version)" "NVIM v0.12.0"

--- a/test/test-zsh-startup.zsh
+++ b/test/test-zsh-startup.zsh
@@ -5,13 +5,14 @@ set -euo pipefail
 source "${0:A:h}/lib.zsh"
 
 plain_home="$(make_temp_dir dotfiles-zsh-plain)"
-mkdir -p "$plain_home/.zprezto"
+mkdir -p "$plain_home/.zprezto" "$plain_home/.local/bin"
 : > "$plain_home/.zprezto/init.zsh"
 
 HOME="$plain_home" ZDOTDIR="$plain_home" /bin/zsh -fc '
   source "$1/zshrc"
   [[ "${DOTFILES_IS_CMUX_RELAY:-0}" == "0" ]] || exit 1
   [[ ! -e "$ZDOTDIR/.zpreztorc" ]] || exit 1
+  [[ ":$PATH:" == *":$HOME/.local/bin:"* ]] || exit 1
 ' _ "$REPO_ROOT"
 
 relay_home="$(make_temp_dir dotfiles-zsh-relay)"

--- a/zshrc
+++ b/zshrc
@@ -8,6 +8,8 @@ fi
 typeset -g DOTFILES_ZSHRC_DIR="${${(%):-%N}:A:h}"
 typeset -gi DOTFILES_IS_CMUX_RELAY=0
 
+export PATH="$HOME/.local/bin:$PATH"
+
 export PYENV_ROOT="$HOME/.pyenv"
 [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
 if (( $+commands[pyenv] )); then


### PR DESCRIPTION
## Summary
- install official Neovim tarballs on supported Linux hosts when nvim is missing or older than 0.11.3
- add ~/.local/bin to zsh PATH so the user-local nvim wins over apt packages
- document the bootstrap behavior and add installer coverage with a fake tarball

## Tests
- zsh test/run.zsh
- git diff --check