### PR TITLE
Enable tmux passthrough and RGB colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ When that overlay repository exists, `init.zsh` links:
 ### tmux
 
 - `tmux.conf` is installed by `init.zsh`
+- `tmux.conf` enables terminal passthrough for cmux notifications from inside tmux
+- `tmux.conf` uses `tmux-256color` with RGB support for color highlighting
 - tmux is kept as an explicit fallback; Prezto tmux auto-start and aliases are disabled
 
 ### Local Helpers

--- a/docs/cmux.md
+++ b/docs/cmux.md
@@ -60,5 +60,9 @@ uv run --with markdown-it-py ~/.local/bin/md-preview-server docs/example.md --ho
 ## tmux Fallback
 
 - `tmux.conf` stays in the repository for direct tmux use
+- `tmux.conf` allows terminal passthrough so cmux notification escape sequences
+  can reach the outer terminal from inside tmux
+- `tmux.conf` uses `tmux-256color` with RGB support so terminal applications,
+  including Codex, keep color highlighting inside tmux
 - Prezto tmux auto-start is disabled
 - Prezto tmux aliases are disabled so `cmux` stays the default entry point

--- a/tmux.conf
+++ b/tmux.conf
@@ -5,6 +5,11 @@ bind-key C-t send-prefix
 
 set-window-option -g xterm-keys on
 
+### Terminal passthrough
+# Let cmux notification escape sequences pass through when tmux is nested
+# inside a cmux-managed terminal.
+set-option -g allow-passthrough on
+
 ### Key mapping
 # split pane in the current directory
 bind s split-window -vc "#{pane_current_path}"
@@ -24,8 +29,10 @@ bind -r J resize-pane -D 5
 bind -r K resize-pane -U 5
 bind -r L resize-pane -R 5
 
-### 256 colors
-set-option -g default-terminal screen-256color
+### Terminal colors
+set-option -g default-terminal tmux-256color
+set-option -ga terminal-features ',xterm-256color:RGB'
+set-option -ga terminal-features ',tmux-256color:RGB'
 
 ### scroll back like vi
 set-option -w -g mode-keys vi


### PR DESCRIPTION
## Summary
- enable tmux terminal passthrough for cmux notification escape sequences
- switch tmux from screen-256color to tmux-256color
- advertise RGB terminal features and document the cmux/tmux behavior

## Tests
- zsh test/run.zsh
- verified tmux reports allow-passthrough on
- verified tmux reports default-terminal tmux-256color and RGB terminal-features
- manually verified cmux notification and color behavior inside tmux