### PR TITLE
Fix Codex colors in tmux panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ When that overlay repository exists, `init.zsh` links:
 - `tmux.conf` is installed by `init.zsh`
 - `tmux.conf` enables mouse support for wheel scrollback and pane selection
 - `tmux.conf` enables terminal passthrough for cmux notifications from inside tmux
-- `tmux.conf` uses `tmux-256color` with RGB support for color highlighting
+- `tmux.conf` uses `tmux-256color` with RGB support for color highlighting,
+  including Ghostty clients
+- `tmux.conf` clears Codex-inherited `NO_COLOR` and `CODEX_CI` from tmux's
+  environment so new panes keep interactive colors
 - tmux is kept as an explicit fallback; Prezto tmux auto-start and aliases are disabled
 
 ### Local Helpers

--- a/docs/cmux.md
+++ b/docs/cmux.md
@@ -63,7 +63,10 @@ uv run --with markdown-it-py ~/.local/bin/md-preview-server docs/example.md --ho
 - `tmux.conf` enables mouse support for wheel scrollback and pane selection
 - `tmux.conf` allows terminal passthrough so cmux notification escape sequences
   can reach the outer terminal from inside tmux
-- `tmux.conf` uses `tmux-256color` with RGB support so terminal applications,
-  including Codex, keep color highlighting inside tmux
+- `tmux.conf` uses `tmux-256color` with RGB support for Ghostty and other
+  configured clients so terminal applications, including Codex, keep color
+  highlighting inside tmux
+- `tmux.conf` clears Codex-inherited `NO_COLOR` and `CODEX_CI` from tmux's
+  environment so later panes do not lose interactive color highlighting
 - Prezto tmux auto-start is disabled
 - Prezto tmux aliases are disabled so `cmux` stays the default entry point

--- a/test/test-tmux-config.zsh
+++ b/test/test-tmux-config.zsh
@@ -1,0 +1,14 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+source "${0:A:h}/lib.zsh"
+
+tmux_conf="$REPO_ROOT/tmux.conf"
+
+grep -q '^set-option -g default-terminal tmux-256color$' "$tmux_conf"
+grep -q "^set-option -ga terminal-features ',xterm-256color:RGB'$" "$tmux_conf"
+grep -q "^set-option -ga terminal-features ',xterm-ghostty:RGB'$" "$tmux_conf"
+grep -q "^set-option -ga terminal-features ',tmux-256color:RGB'$" "$tmux_conf"
+grep -q '^set-environment -gu NO_COLOR$' "$tmux_conf"
+grep -q '^set-environment -gu CODEX_CI$' "$tmux_conf"

--- a/tmux.conf
+++ b/tmux.conf
@@ -36,7 +36,13 @@ bind -r L resize-pane -R 5
 ### Terminal colors
 set-option -g default-terminal tmux-256color
 set-option -ga terminal-features ',xterm-256color:RGB'
+set-option -ga terminal-features ',xterm-ghostty:RGB'
 set-option -ga terminal-features ',tmux-256color:RGB'
+
+### Environment
+# Keep tmux panes interactive even if the server was started under Codex.
+set-environment -gu NO_COLOR
+set-environment -gu CODEX_CI
 
 ### scroll back like vi
 set-option -w -g mode-keys vi


### PR DESCRIPTION
## Summary
- enable RGB terminal features for Ghostty tmux clients
- clear Codex-inherited NO_COLOR and CODEX_CI from tmux global environment
- add a focused tmux config smoke test and update docs

## Tests
- git diff --check
- zsh test/test-tmux-config.zsh
- tmux source-file tmux.conf