### PR TITLE
Add Herdr configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Managed configs:
 - `tmux`
 - `ssh`
 - `Ghostty`
+- `Herdr`
 - `VS Code`
 - local helper scripts
 
@@ -113,6 +114,14 @@ When that overlay repository exists, `init.zsh` links:
 
 - `ghostty/config.ghostty` is linked to both
   `~/.config/ghostty/config.ghostty` and `~/.config/ghostty/config`
+
+### Herdr
+
+- `herdr/config.toml` is linked to `~/.config/herdr/config.toml`
+- Herdr uses `ctrl+t` as the prefix key, matching the tmux prefix used in this setup
+- Agent sidebar sorting prioritizes panes that need attention
+- Sound and pane history replay are disabled by default to avoid noisy shared sessions
+  and persistent terminal output containing secrets
 
 ### VS Code
 

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -1,0 +1,53 @@
+onboarding = false
+
+[update]
+channel = "stable"
+version_check = true
+manifest_check = true
+
+[terminal]
+shell_mode = "auto"
+new_cwd = "follow"
+
+[theme]
+name = "terminal"
+
+[ui]
+sidebar_width = 32
+sidebar_min_width = 20
+sidebar_max_width = 40
+confirm_close = true
+prompt_new_tab_name = false
+pane_borders = true
+pane_gaps = false
+show_agent_labels_on_pane_borders = true
+agent_panel_sort = "priority"
+mouse_scroll_lines = 5
+
+[ui.toast]
+delivery = "terminal"
+delay_seconds = 2
+
+[ui.toast.clipboard]
+enabled = false
+
+[ui.sound]
+enabled = false
+
+[advanced]
+scrollback_limit_bytes = 20971520
+
+[session]
+resume_agents_on_restore = true
+
+[experimental]
+pane_history = false
+allow_nested = false
+kitty_graphics = false
+reveal_hidden_cursor_for_cjk_ime = true
+cjk_ime_agents = ["codex", "claude", "opencode", "cursor", "copilot"]
+cjk_ime_cursor_shape = "steady_block"
+switch_ascii_input_source_in_prefix = true
+
+[keys]
+prefix = "ctrl+t"

--- a/init.zsh
+++ b/init.zsh
@@ -331,6 +331,8 @@ install_dotfiles() {
     mkdir -p ~/.config/ghostty
     link_files "$DOTFILES_DIR/ghostty/config.ghostty" ~/.config/ghostty/config.ghostty
     link_files "$DOTFILES_DIR/ghostty/config.ghostty" ~/.config/ghostty/config
+    mkdir -p ~/.config/herdr
+    link_files "$DOTFILES_DIR/herdr/config.toml" ~/.config/herdr/config.toml
 
     # VS Code settings (macOS specific)
     if [[ "$(uname)" == "Darwin" ]]; then

--- a/test/test-init.zsh
+++ b/test/test-init.zsh
@@ -15,6 +15,7 @@ mkdir -p \
   "$tmp_home/.local/bin" \
   "$tmp_home/.ssh" \
   "$tmp_home/.config/ghostty" \
+  "$tmp_home/.config/herdr" \
   "$tmp_home/.config/nvim" \
   "$private_dir/ssh"
 print -r -- '#!/bin/sh' > "$tmp_home/.deno/bin/deno"
@@ -58,6 +59,7 @@ assert_symlink_target "$tmp_home/.codex/skills/cmux-markdown-preview" "$REPO_ROO
 assert_symlink_target "$tmp_home/.ssh/config" "$REPO_ROOT/ssh/config"
 assert_symlink_target "$tmp_home/.config/ghostty/config.ghostty" "$REPO_ROOT/ghostty/config.ghostty"
 assert_symlink_target "$tmp_home/.config/ghostty/config" "$REPO_ROOT/ghostty/config.ghostty"
+assert_symlink_target "$tmp_home/.config/herdr/config.toml" "$REPO_ROOT/herdr/config.toml"
 assert_symlink_target "$tmp_home/.zshrc.local" "$private_dir/zshrc.local"
 assert_symlink_target "$tmp_home/.ssh/config.local" "$private_dir/ssh/config.local"
 


### PR DESCRIPTION
## Summary
- add a managed Herdr config with ctrl+t prefix and agent-focused defaults
- link Herdr config from init.zsh
- document Herdr as a managed config and cover the symlink in init tests

## Tests
- zsh test/test-init.zsh
- python3 -c 'import pathlib,tomllib; tomllib.loads(pathlib.Path("herdr/config.toml").read_text()); print("toml ok")'