### PR TITLE
docs: add Herdr remote notification checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ When that overlay repository exists, `init.zsh` links:
 - Agent sidebar sorting prioritizes panes that need attention
 - Sound and pane history replay are disabled by default to avoid noisy shared sessions
   and persistent terminal output containing secrets
+- For remote notification checks, see `docs/herdr.md`
 
 ### VS Code
 

--- a/docs/herdr.md
+++ b/docs/herdr.md
@@ -1,0 +1,36 @@
+# Herdr Notes
+
+This repository manages shared Herdr defaults in `herdr/config.toml`.
+Machine-specific Herdr behavior should stay in local config where possible.
+
+## Remote Notifications
+
+Herdr remote sessions use the Herdr server and agent integrations on the remote
+host where the agent runs. If agent completion sounds do not play after opening
+a remote session, check the remote host rather than the local client first.
+
+On the remote host, make sure the agent integration is installed and current:
+
+```sh
+herdr integration status
+herdr integration install codex
+```
+
+Also make sure the remote Herdr config enables sounds:
+
+```toml
+[ui.sound]
+enabled = true
+```
+
+Reload the remote server after changing `~/.config/herdr/config.toml`:
+
+```sh
+herdr server reload-config
+```
+
+You can verify the remote notification path with:
+
+```sh
+herdr notification show "Herdr remote test" --body "done sound test" --sound done
+```


### PR DESCRIPTION
## Summary
- Add a dedicated Herdr notes page for remote notification checks
- Document that Herdr remote agent sounds depend on the remote host server and integrations
- Add remote-side checks for Codex integration, ui.sound, config reload, and notification test
- Link the README Herdr section to the new notes page

## Testing
- Not run; documentation-only change