### PR TITLE
Add herdr file viewer shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ When that overlay repository exists, `init.zsh` links:
 
 - `herdr/config.toml` is linked to `~/.config/herdr/config.toml`
 - Herdr uses `ctrl+t` as the prefix key, matching the tmux prefix used in this setup
+- `ctrl+t f` opens the `herdr-file-viewer` plugin in a split; `ctrl+t F` opens it in a tab
 - Agent sidebar sorting prioritizes panes that need attention
 - Sound and pane history replay are disabled by default to avoid noisy shared sessions
   and persistent terminal output containing secrets

--- a/docs/herdr.md
+++ b/docs/herdr.md
@@ -3,6 +3,23 @@
 This repository manages shared Herdr defaults in `herdr/config.toml`.
 Machine-specific Herdr behavior should stay in local config where possible.
 
+## File Viewer
+
+This setup binds the `herdr-file-viewer` plugin to `ctrl+t f` for a split pane
+and `ctrl+t F` for a new tab. Install the plugin after linking the config:
+
+```sh
+herdr plugin install smarzban/herdr-file-viewer
+herdr server reload-config
+```
+
+For styled Markdown, diffs, and syntax highlighting, install its optional
+renderers on macOS:
+
+```sh
+brew install glow git-delta bat
+```
+
 ## Remote Notifications
 
 Herdr remote sessions use the Herdr server and agent integrations on the remote

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -51,3 +51,13 @@ switch_ascii_input_source_in_prefix = true
 
 [keys]
 prefix = "ctrl+t"
+
+[[keys.command]]
+key = "prefix+f"
+type = "shell"
+command = "herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer"
+
+[[keys.command]]
+key = "prefix+shift+f"
+type = "shell"
+command = "herdr plugin action invoke open-file-viewer-tab --plugin herdr-file-viewer"


### PR DESCRIPTION
## Summary
- add herdr-file-viewer split and tab shortcuts
- document installation and optional renderers

## Testing
- zsh test/test-init.zsh