### PR TITLE
feat: add direct Herdr navigation keys

### DIFF
--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -51,6 +51,10 @@ switch_ascii_input_source_in_prefix = true
 
 [keys]
 prefix = "ctrl+t"
+previous_workspace = "alt+left"
+next_workspace = "alt+right"
+previous_tab = "alt+up"
+next_tab = "alt+down"
 
 [[keys.command]]
 key = "prefix+f"


### PR DESCRIPTION
## Summary
- add Option+arrow shortcuts for Herdr workspace and tab navigation
- keep the existing Ctrl+T prefix bindings unchanged

## Test plan
- zsh test/test-init.zsh
- git diff --check