### PR TITLE
Add overleaf.nvim integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ When that overlay repository exists, `init.zsh` links:
 - On Linux x86_64/arm64, `init.zsh` installs the official Neovim tarball to
   `~/.local/opt/dotfiles/` and links `~/.local/bin/nvim` when no Neovim at
   least `0.11.3` is available
+- `richwomanbtc/overleaf.nvim` is installed for Neovim 0.10+; its Node bridge
+  is built by dein, so it requires Node.js 18+
+- To mirror an Overleaf project for Codex CLI, create the untracked
+  `~/.config/nvim/overleaf.local.lua` with (for example)
+  `return { sync_dir = vim.fn.expand('~/Documents/overleaf') }`. Put the
+  `OVERLEAF_COOKIE` only in the project-local `.env` file supported by the
+  plugin; never add it to this repository or the local Lua file.
 
 ### SSH
 

--- a/vim/dein/userconfig/plugins.toml
+++ b/vim/dein/userconfig/plugins.toml
@@ -81,6 +81,11 @@
   repo = 'tpope/vim-commentary'
 
 [[plugins]]
+  repo = 'richwomanbtc/overleaf.nvim'
+  if = "has('nvim-0.10')"
+  build = 'cd node && npm install'
+
+[[plugins]]
 repo = 'halkn/lightline-lsp'
 
 [[plugins]]

--- a/vimrc
+++ b/vimrc
@@ -107,6 +107,24 @@ if dein#check_install()
   call dein#install()
 endif
 
+" overleaf.nvim is Neovim-only.  Keep account-specific settings, especially
+" session cookies, out of this tracked configuration.
+if has('nvim-0.10')
+  lua << EOF
+local options = {}
+local local_config = vim.fn.stdpath('config') .. '/overleaf.local.lua'
+local loaded, result = pcall(dofile, local_config)
+if loaded and type(result) == 'table' then
+  options = result
+end
+
+local available, overleaf = pcall(require, 'overleaf')
+if available then
+  overleaf.setup(options)
+end
+EOF
+endif
+
 syntax enable
 filetype plugin indent on     " (5)
 


### PR DESCRIPTION
## Summary
- add overleaf.nvim to the Neovim dein plugin list
- build its Node bridge during installation
- document an untracked local sync directory for Codex CLI and keep credentials out of dotfiles

## Validation
- zsh test/test-nvim-startup.zsh
- zsh test/test-vim-startup.zsh (skipped: pylsp-all is unavailable)